### PR TITLE
Create `NasbMode` for Nickelodeon All-Star Brawl

### DIFF
--- a/HayB0XX/contrib/NasbMode.cpp
+++ b/HayB0XX/contrib/NasbMode.cpp
@@ -1,0 +1,41 @@
+#include "NasbMode.h"
+#include "ControllerMode.h"
+
+#define ANALOG_STICK_MIN 48
+#define ANALOG_STICK_NEUTRAL 128
+#define ANALOG_STICK_MAX 208
+
+NasbMode::NasbMode(state::InputState &rInputState, CommunicationBackend *communicationBackend)
+    : ControllerMode(socd::SOCD_NEUTRAL, rInputState, communicationBackend)
+{
+  mSocdPairs.push_back(socd::SocdPair{&rInputState.left, &rInputState.right});
+  mSocdPairs.push_back(socd::SocdPair{&rInputState.down, &rInputState.up});
+  mSocdPairs.push_back(socd::SocdPair{&rInputState.c_left, &rInputState.c_right});
+  mSocdPairs.push_back(socd::SocdPair{&rInputState.c_down, &rInputState.c_up});
+}
+
+void NasbMode::HandleSocd()
+{
+  InputMode::HandleSocd();
+}
+
+void NasbMode::UpdateDigitalOutputs()
+{
+  mOutputState.dpadUp = mrInputState.midshield;
+  mOutputState.start = mrInputState.start;
+  mOutputState.a = mrInputState.a;
+  mOutputState.b = mrInputState.b;
+  mOutputState.y = mrInputState.x || mrInputState.y;
+  mOutputState.x = mrInputState.mod_y || mrInputState.lightshield;
+  mOutputState.buttonR = mrInputState.z;
+  mOutputState.triggerRDigital = mrInputState.l || mrInputState.r;
+  mOutputState.triggerLDigital = mrInputState.mod_x;
+}
+
+void NasbMode::UpdateAnalogOutputs()
+{
+  HandleVectors(mrInputState.left, mrInputState.right, mrInputState.down,
+                mrInputState.up, mrInputState.c_left, mrInputState.c_right,
+                mrInputState.c_down, mrInputState.c_up, ANALOG_STICK_MIN,
+                ANALOG_STICK_NEUTRAL, ANALOG_STICK_MAX);
+}

--- a/HayB0XX/contrib/NasbMode.h
+++ b/HayB0XX/contrib/NasbMode.h
@@ -1,0 +1,19 @@
+#ifndef NASBMODE_H_C65L457Q
+#define NASBMODE_H_C65L457Q
+
+#include "CommunicationBackend.h"
+#include "ControllerMode.h"
+#include "socd.h"
+#include "state.h"
+
+class NasbMode : public ControllerMode {
+public:
+  NasbMode(state::InputState &rInputState, CommunicationBackend *communicationBackend);
+  void UpdateDigitalOutputs();
+  void UpdateAnalogOutputs();
+
+private:
+  void HandleSocd();
+};
+
+#endif /* end of include guard: NASBMODE_H_C65L457Q */


### PR DESCRIPTION
I just threw this together for myself. Hopefully it can be useful to others.

Feel free to push to my branch for any desired changes.

## SOCD
SOCD resolution is neutral on both axes, emulating how keyboard behaves in-game.

## Controls
Assuming in-game defaults. Buttons describe Hax-layout locations.

Function|Buttons
-|-
Move|Analog stick
Attack|`A` and C-stick
Strong|`MY` or `LS`
Special|`B`
Jump|`X` or `Y`
Defend|`L` or `R`
Grab Macro|`Z`
Strafe|`MX`
Taunt|`MS`