### PR TITLE
Map unused Smash Box modifiers to `select` and `home`

### DIFF
--- a/config/smashbox/config.cpp
+++ b/config/smashbox/config.cpp
@@ -24,6 +24,8 @@ GpioButtonMapping button_mappings[] = {
 
     { &InputState::mod_x,       28},
     { &InputState::mod_y,       29},
+    { &InputState::select,      30},
+    { &InputState::home,        31},
 
     { &InputState::start,       50},
 


### PR DESCRIPTION
Maps OEM "Y1" to Select and "Y2" to Home, which `Melee20Button` maps to d-pad left and d-pad right for Uncle Punch, etc.