### PR TITLE
Replace output assignments with normalized coordinate functions

### DIFF
--- a/HAL/avr/src/comms/N64Backend.cpp
+++ b/HAL/avr/src/comms/N64Backend.cpp
@@ -45,14 +45,14 @@ void N64Backend::SendReport() {
     _data.report.ddown = _outputs.dpadDown;
     _data.report.dup = _outputs.dpadUp;
     // Somewhat ugly way of mapping right stick to C-Pad
-    _data.report.cleft = _outputs.rightStickX < 128;
-    _data.report.cright = _outputs.rightStickX > 128;
-    _data.report.cdown = _outputs.rightStickY < 128;
-    _data.report.cup = _outputs.rightStickY > 128;
+    _data.report.cleft = _outputs.rightStickX < ANALOG_STICK_NEUTRAL;
+    _data.report.cright = _outputs.rightStickX > ANALOG_STICK_NEUTRAL;
+    _data.report.cdown = _outputs.rightStickY < ANALOG_STICK_NEUTRAL;
+    _data.report.cup = _outputs.rightStickY > ANALOG_STICK_NEUTRAL;
 
     // Analog outputs - converted from unsigned to signed 8-bit integers
-    _data.report.xAxis = _outputs.leftStickX - 128;
-    _data.report.yAxis = _outputs.leftStickY - 128;
+    _data.report.xAxis = _outputs.leftStickX - ANALOG_STICK_NEUTRAL;
+    _data.report.yAxis = _outputs.leftStickY - ANALOG_STICK_NEUTRAL;
 
     // Send outputs to console.
     _n64->write(_data);

--- a/HAL/pico/src/comms/DInputBackend.cpp
+++ b/HAL/pico/src/comms/DInputBackend.cpp
@@ -48,10 +48,10 @@ void DInputBackend::SendReport() {
     _gamepad->setButton(12, _outputs.home);
 
     // Analog outputs
-    _gamepad->leftXAxis(_outputs.leftStickX + 128);
-    _gamepad->leftYAxis(128 - _outputs.leftStickY);
-    _gamepad->rightXAxis(_outputs.rightStickX + 128);
-    _gamepad->rightYAxis(128 - _outputs.rightStickY);
+    _gamepad->leftXAxis(_outputs.leftStickX + ANALOG_STICK_NEUTRAL);
+    _gamepad->leftYAxis(ANALOG_STICK_NEUTRAL - _outputs.leftStickY);
+    _gamepad->rightXAxis(_outputs.rightStickX + ANALOG_STICK_NEUTRAL);
+    _gamepad->rightYAxis(ANALOG_STICK_NEUTRAL - _outputs.rightStickY);
     _gamepad->triggerLAnalog(_outputs.triggerLAnalog + 129);
     _gamepad->triggerRAnalog(_outputs.triggerRAnalog + 129);
 

--- a/config/lbx/modes/MeleeLbx.cpp
+++ b/config/lbx/modes/MeleeLbx.cpp
@@ -18,7 +18,7 @@ void MeleeLbx::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
 void MeleeLbx::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     Melee20Button::UpdateAnalogOutputs(inputs, outputs);
     if (inputs.select) {
-        outputs.rightStickX = 128;
-        outputs.rightStickY = 128;
+        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
+        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
     }
 }

--- a/config/lbx/modes/MeleeLbx.cpp
+++ b/config/lbx/modes/MeleeLbx.cpp
@@ -1,7 +1,6 @@
 #include "MeleeLbx.hpp"
 
 #define ANALOG_STICK_MIN 48
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 208
 
 MeleeLbx::MeleeLbx(socd::SocdType socd_type) : Melee20Button(socd_type) {}

--- a/config/lbx/modes/MeleeLbx.cpp
+++ b/config/lbx/modes/MeleeLbx.cpp
@@ -1,7 +1,5 @@
 #include "MeleeLbx.hpp"
 
-#define ANALOG_STICK_LENGTH 80
-
 MeleeLbx::MeleeLbx(socd::SocdType socd_type) : Melee20Button(socd_type) {}
 
 void MeleeLbx::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {

--- a/config/lbx/modes/MeleeLbx.cpp
+++ b/config/lbx/modes/MeleeLbx.cpp
@@ -1,7 +1,6 @@
 #include "MeleeLbx.hpp"
 
-#define ANALOG_STICK_MIN 48
-#define ANALOG_STICK_MAX 208
+#define ANALOG_STICK_LENGTH 80
 
 MeleeLbx::MeleeLbx(socd::SocdType socd_type) : Melee20Button(socd_type) {}
 

--- a/include/core/ControllerMode.hpp
+++ b/include/core/ControllerMode.hpp
@@ -8,7 +8,7 @@
 class ControllerMode : public InputMode {
   public:
     ControllerMode(socd::SocdType socd_type, uint8_t analog_stick_length = 127);
-    void UpdateOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateOutputs(InputState &inputs, OutputState* outputs);
     void ResetDirections();
     virtual void UpdateDirections(
         bool lsLeft,
@@ -18,24 +18,24 @@ class ControllerMode : public InputMode {
         bool rsLeft,
         bool rsRight,
         bool rsDown,
-        bool rsUp,
-        OutputState &outputs
+        bool rsUp
     );
 
   protected:
     StickDirections directions;
+    OutputState* outputs = nullptr;
 
-    void SetLeftStickX(OutputState &outputs, const uint16_t &value);
-    void SetLeftStickY(OutputState &outputs, const uint16_t &value);
+    void SetLeftStickX(const uint16_t &value);
+    void SetLeftStickY(const uint16_t &value);
     void SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue);
-    void SetLeftStick(OutputState &outputs, const uint16_t &xValue, const uint16_t &yValue);
-    void SetRightStick(OutputState &outputs, const uint16_t &xValue, const uint16_t &yValue);
+    void SetLeftStick(const uint16_t &xValue, const uint16_t &yValue);
+    void SetRightStick(const uint16_t &xValue, const uint16_t &yValue);
 
   private:
     uint8_t analog_stick_length;
 
-    virtual void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) = 0;
-    virtual void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) = 0;
+    virtual void UpdateDigitalOutputs(InputState &inputs) = 0;
+    virtual void UpdateAnalogOutputs(InputState &inputs) = 0;
 
     void SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value);
 };

--- a/include/core/ControllerMode.hpp
+++ b/include/core/ControllerMode.hpp
@@ -7,7 +7,7 @@
 
 class ControllerMode : public InputMode {
   public:
-    ControllerMode(socd::SocdType socd_type);
+    ControllerMode(socd::SocdType socd_type, uint8_t analog_stick_length = 127);
     void UpdateOutputs(InputState &inputs, OutputState &outputs);
     void ResetDirections();
     virtual void UpdateDirections(
@@ -19,9 +19,6 @@ class ControllerMode : public InputMode {
         bool rsRight,
         bool rsDown,
         bool rsUp,
-        uint8_t analogStickMin,
-        uint8_t analogStickNeutral,
-        uint8_t analogStickMax,
         OutputState &outputs
     );
 
@@ -35,6 +32,8 @@ class ControllerMode : public InputMode {
     void SetRightStick(OutputState &outputs, const uint16_t &xValue, const uint16_t &yValue);
 
   private:
+    uint8_t analog_stick_length;
+
     virtual void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) = 0;
     virtual void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) = 0;
 

--- a/include/core/ControllerMode.hpp
+++ b/include/core/ControllerMode.hpp
@@ -28,9 +28,17 @@ class ControllerMode : public InputMode {
   protected:
     StickDirections directions;
 
+    void SetLeftStickX(OutputState &outputs, const StickDirections &directions, const uint16_t &value);
+    void SetLeftStickY(OutputState &outputs, const StickDirections &directions, const uint16_t &value);
+    void SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue);
+    void SetLeftStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue);
+    void SetRightStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue);
+
   private:
     virtual void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) = 0;
     virtual void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) = 0;
+
+    void SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value);
 };
 
 #endif

--- a/include/core/ControllerMode.hpp
+++ b/include/core/ControllerMode.hpp
@@ -23,22 +23,13 @@ class ControllerMode : public InputMode {
 
   protected:
     StickDirections directions;
+    uint8_t _analog_stick_length;
     OutputState* _outputs = nullptr;
 
-    void SetLeftStickX(const uint16_t &value);
-    void SetLeftStickY(const uint16_t &value);
-    void SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue);
-    void SetLeftStick(const uint16_t &xValue, const uint16_t &yValue);
-    void SetRightStick(const uint16_t &xValue, const uint16_t &yValue);
-    void SetAngledFSmash(const uint16_t &xValue, const uint16_t yValue);
-
   private:
-    uint8_t analog_stick_length;
 
     virtual void UpdateDigitalOutputs() = 0;
     virtual void UpdateAnalogOutputs() = 0;
-
-    void SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value);
 };
 
 #endif

--- a/include/core/ControllerMode.hpp
+++ b/include/core/ControllerMode.hpp
@@ -28,11 +28,11 @@ class ControllerMode : public InputMode {
   protected:
     StickDirections directions;
 
-    void SetLeftStickX(OutputState &outputs, const StickDirections &directions, const uint16_t &value);
-    void SetLeftStickY(OutputState &outputs, const StickDirections &directions, const uint16_t &value);
+    void SetLeftStickX(OutputState &outputs, const uint16_t &value);
+    void SetLeftStickY(OutputState &outputs, const uint16_t &value);
     void SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue);
-    void SetLeftStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue);
-    void SetRightStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue);
+    void SetLeftStick(OutputState &outputs, const uint16_t &xValue, const uint16_t &yValue);
+    void SetRightStick(OutputState &outputs, const uint16_t &xValue, const uint16_t &yValue);
 
   private:
     virtual void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) = 0;

--- a/include/core/ControllerMode.hpp
+++ b/include/core/ControllerMode.hpp
@@ -30,6 +30,7 @@ class ControllerMode : public InputMode {
     void SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue);
     void SetLeftStick(const uint16_t &xValue, const uint16_t &yValue);
     void SetRightStick(const uint16_t &xValue, const uint16_t &yValue);
+    void SetAngledFSmash(const uint16_t &xValue, const uint16_t yValue);
 
   private:
     uint8_t analog_stick_length;

--- a/include/core/ControllerMode.hpp
+++ b/include/core/ControllerMode.hpp
@@ -8,7 +8,7 @@
 class ControllerMode : public InputMode {
   public:
     ControllerMode(socd::SocdType socd_type, uint8_t analog_stick_length = 127);
-    void UpdateOutputs(InputState &inputs, OutputState* outputs);
+    void UpdateOutputs(InputState* inputs, OutputState* outputs);
     void ResetDirections();
     virtual void UpdateDirections(
         bool lsLeft,
@@ -23,7 +23,7 @@ class ControllerMode : public InputMode {
 
   protected:
     StickDirections directions;
-    OutputState* outputs = nullptr;
+    OutputState* _outputs = nullptr;
 
     void SetLeftStickX(const uint16_t &value);
     void SetLeftStickY(const uint16_t &value);
@@ -34,8 +34,8 @@ class ControllerMode : public InputMode {
   private:
     uint8_t analog_stick_length;
 
-    virtual void UpdateDigitalOutputs(InputState &inputs) = 0;
-    virtual void UpdateAnalogOutputs(InputState &inputs) = 0;
+    virtual void UpdateDigitalOutputs() = 0;
+    virtual void UpdateAnalogOutputs() = 0;
 
     void SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value);
 };

--- a/include/core/InputMode.hpp
+++ b/include/core/InputMode.hpp
@@ -15,8 +15,9 @@ class InputMode {
     /* Exposed to child classes so that game modes are able to have different behaviour depending on
      * SOCD cleaning mode. */
     socd::SocdType _socd_type;
+    InputState* _inputs = nullptr;
 
-    virtual void HandleSocd(InputState &inputs);
+    virtual void HandleSocd();
 
   private:
     socd::SocdState *_socd_states = nullptr;

--- a/include/core/state.hpp
+++ b/include/core/state.hpp
@@ -72,10 +72,10 @@ typedef struct outputstate {
     bool rightStickClick = false;
 
     // Analog outputs.
-    uint8_t leftStickX = 128;
-    uint8_t leftStickY = 128;
-    uint8_t rightStickX = 128;
-    uint8_t rightStickY = 128;
+    uint8_t leftStickX = ANALOG_STICK_NEUTRAL;
+    uint8_t leftStickY = ANALOG_STICK_NEUTRAL;
+    uint8_t rightStickX = ANALOG_STICK_NEUTRAL;
+    uint8_t rightStickY = ANALOG_STICK_NEUTRAL;
     uint8_t triggerRAnalog = 0;
     uint8_t triggerLAnalog = 0;
 } OutputState;

--- a/include/core/state.hpp
+++ b/include/core/state.hpp
@@ -4,8 +4,6 @@
 #include "stdlib.hpp"
 
 #define ANALOG_STICK_NEUTRAL 128
-#define ANALOG_STICK_MIN (ANALOG_STICK_NEUTRAL - ANALOG_STICK_LENGTH)
-#define ANALOG_STICK_MAX (ANALOG_STICK_NEUTRAL + ANALOG_STICK_LENGTH)
 
 // Button state.
 typedef struct inputstate {

--- a/include/core/state.hpp
+++ b/include/core/state.hpp
@@ -3,6 +3,8 @@
 
 #include "stdlib.hpp"
 
+#define ANALOG_STICK_NEUTRAL 128
+
 // Button state.
 typedef struct inputstate {
     // Rectangle inputs.

--- a/include/core/state.hpp
+++ b/include/core/state.hpp
@@ -4,6 +4,8 @@
 #include "stdlib.hpp"
 
 #define ANALOG_STICK_NEUTRAL 128
+#define ANALOG_STICK_MIN (ANALOG_STICK_NEUTRAL - ANALOG_STICK_LENGTH)
+#define ANALOG_STICK_MAX (ANALOG_STICK_NEUTRAL + ANALOG_STICK_LENGTH)
 
 // Button state.
 typedef struct inputstate {

--- a/include/modes/FgcMode.hpp
+++ b/include/modes/FgcMode.hpp
@@ -11,8 +11,8 @@ class FgcMode : public ControllerMode {
 
   private:
     void HandleSocd(InputState &inputs);
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/FgcMode.hpp
+++ b/include/modes/FgcMode.hpp
@@ -10,9 +10,9 @@ class FgcMode : public ControllerMode {
     FgcMode(socd::SocdType socd_type);
 
   private:
-    void HandleSocd(InputState &inputs);
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void HandleSocd();
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/Melee18Button.hpp
+++ b/include/modes/Melee18Button.hpp
@@ -12,9 +12,9 @@ class Melee18Button : public ControllerMode {
   private:
     bool horizontal_socd;
 
-    void HandleSocd(InputState &inputs);
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void HandleSocd();
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/Melee18Button.hpp
+++ b/include/modes/Melee18Button.hpp
@@ -13,8 +13,8 @@ class Melee18Button : public ControllerMode {
     bool horizontal_socd;
 
     void HandleSocd(InputState &inputs);
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/Melee18Button.hpp
+++ b/include/modes/Melee18Button.hpp
@@ -1,18 +1,15 @@
 #ifndef _MODES_MELEE18BUTTON_HPP
 #define _MODES_MELEE18BUTTON_HPP
 
-#include "core/ControllerMode.hpp"
+#include "modes/PlatformFighter.hpp"
 #include "core/socd.hpp"
 #include "core/state.hpp"
 
-class Melee18Button : public ControllerMode {
+class Melee18Button : public PlatformFighter {
   public:
     Melee18Button(socd::SocdType socd_type);
 
   private:
-    bool horizontal_socd;
-
-    void HandleSocd();
     void UpdateDigitalOutputs();
     void UpdateAnalogOutputs();
 };

--- a/include/modes/Melee20Button.hpp
+++ b/include/modes/Melee20Button.hpp
@@ -1,22 +1,17 @@
 #ifndef _MODES_MELEE20BUTTON_HPP
 #define _MODES_MELEE20BUTTON_HPP
 
-#include "core/ControllerMode.hpp"
+#include "modes/PlatformFighter.hpp"
 #include "core/socd.hpp"
 #include "core/state.hpp"
 
-class Melee20Button : public ControllerMode {
+class Melee20Button : public PlatformFighter {
   public:
     Melee20Button(socd::SocdType socd_type);
 
-  protected:
+  private:
     virtual void UpdateDigitalOutputs();
     virtual void UpdateAnalogOutputs();
-
-  private:
-    bool horizontal_socd;
-
-    void HandleSocd();
 };
 
 #endif

--- a/include/modes/Melee20Button.hpp
+++ b/include/modes/Melee20Button.hpp
@@ -10,13 +10,13 @@ class Melee20Button : public ControllerMode {
     Melee20Button(socd::SocdType socd_type);
 
   protected:
-    virtual void UpdateDigitalOutputs(InputState &inputs);
-    virtual void UpdateAnalogOutputs(InputState &inputs);
+    virtual void UpdateDigitalOutputs();
+    virtual void UpdateAnalogOutputs();
 
   private:
     bool horizontal_socd;
 
-    void HandleSocd(InputState &inputs);
+    void HandleSocd();
 };
 
 #endif

--- a/include/modes/Melee20Button.hpp
+++ b/include/modes/Melee20Button.hpp
@@ -10,8 +10,8 @@ class Melee20Button : public ControllerMode {
     Melee20Button(socd::SocdType socd_type);
 
   protected:
-    virtual void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    virtual void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    virtual void UpdateDigitalOutputs(InputState &inputs);
+    virtual void UpdateAnalogOutputs(InputState &inputs);
 
   private:
     bool horizontal_socd;

--- a/include/modes/PlatformFighter.hpp
+++ b/include/modes/PlatformFighter.hpp
@@ -13,6 +13,13 @@ class PlatformFighter : public ControllerMode {
     bool _horizontal_socd;
 
     void HandleSocd();
+    void SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value);
+    void SetLeftStickX(const uint16_t &value);
+    void SetLeftStickY(const uint16_t &value);
+    void SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue);
+    void SetLeftStick(const uint16_t &xValue, const uint16_t &yValue);
+    void SetRightStick(const uint16_t &xValue, const uint16_t &yValue);
+    void SetAngledFSmash(const uint16_t &xValue, const uint16_t yValue);
 };
 
 #endif

--- a/include/modes/PlatformFighter.hpp
+++ b/include/modes/PlatformFighter.hpp
@@ -19,7 +19,7 @@ class PlatformFighter : public ControllerMode {
     void SetLeftStickY(const uint16_t &value);
     void SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue);
     void SetLeftStick(const uint16_t &xValue, const uint16_t &yValue);
-    void SetRightStick(const uint16_t &xValue, const uint16_t &yValue);
+    void SetCStick(const uint16_t &xValue, const uint16_t &yValue);
     void SetAngledFSmash(const uint16_t &xValue, const uint16_t yValue);
 };
 

--- a/include/modes/PlatformFighter.hpp
+++ b/include/modes/PlatformFighter.hpp
@@ -13,6 +13,7 @@ class PlatformFighter : public ControllerMode {
     bool _horizontal_socd;
 
     void HandleSocd();
+    void UpdateDirections();
     void SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value);
     void SetLeftStickX(const uint16_t &value);
     void SetLeftStickY(const uint16_t &value);

--- a/include/modes/PlatformFighter.hpp
+++ b/include/modes/PlatformFighter.hpp
@@ -1,0 +1,18 @@
+#ifndef _MODES_PLATFORMFIGHTER_HPP
+#define _MODES_PLATFORMFIGHTER_HPP
+
+#include "core/ControllerMode.hpp"
+#include "core/socd.hpp"
+#include "core/state.hpp"
+
+class PlatformFighter : public ControllerMode {
+  public:
+    PlatformFighter(socd::SocdType socd_type, uint8_t analog_stick_length = 100);
+
+  protected:
+    bool _horizontal_socd;
+
+    void HandleSocd();
+};
+
+#endif

--- a/include/modes/ProjectM.hpp
+++ b/include/modes/ProjectM.hpp
@@ -1,20 +1,18 @@
 #ifndef _MODES_PROJECTM_HPP
 #define _MODES_PROJECTM_HPP
 
-#include "core/ControllerMode.hpp"
+#include "modes/PlatformFighter.hpp"
 #include "core/socd.hpp"
 #include "core/state.hpp"
 
-class ProjectM : public ControllerMode {
+class ProjectM : public PlatformFighter {
   public:
     ProjectM(socd::SocdType socd_type, bool ledgedash_max_jump_traj, bool true_z_press);
 
   private:
     bool ledgedash_max_jump_traj;
     bool true_z_press;
-    bool horizontal_socd;
 
-    void HandleSocd();
     void UpdateDigitalOutputs();
     void UpdateAnalogOutputs();
 };

--- a/include/modes/ProjectM.hpp
+++ b/include/modes/ProjectM.hpp
@@ -15,8 +15,8 @@ class ProjectM : public ControllerMode {
     bool horizontal_socd;
 
     void HandleSocd(InputState &inputs);
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/ProjectM.hpp
+++ b/include/modes/ProjectM.hpp
@@ -14,9 +14,9 @@ class ProjectM : public ControllerMode {
     bool true_z_press;
     bool horizontal_socd;
 
-    void HandleSocd(InputState &inputs);
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void HandleSocd();
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/RivalsOfAether.hpp
+++ b/include/modes/RivalsOfAether.hpp
@@ -10,8 +10,8 @@ class RivalsOfAether : public ControllerMode {
     RivalsOfAether(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/RivalsOfAether.hpp
+++ b/include/modes/RivalsOfAether.hpp
@@ -1,11 +1,11 @@
 #ifndef _MODES_RIVALSOFAETHER_HPP
 #define _MODES_RIVALSOFAETHER_HPP
 
-#include "core/ControllerMode.hpp"
+#include "modes/PlatformFighter.hpp"
 #include "core/socd.hpp"
 #include "core/state.hpp"
 
-class RivalsOfAether : public ControllerMode {
+class RivalsOfAether : public PlatformFighter {
   public:
     RivalsOfAether(socd::SocdType socd_type);
 

--- a/include/modes/RivalsOfAether.hpp
+++ b/include/modes/RivalsOfAether.hpp
@@ -10,8 +10,8 @@ class RivalsOfAether : public ControllerMode {
     RivalsOfAether(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/Ultimate.hpp
+++ b/include/modes/Ultimate.hpp
@@ -10,8 +10,8 @@ class Ultimate : public ControllerMode {
     Ultimate(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/Ultimate.hpp
+++ b/include/modes/Ultimate.hpp
@@ -10,8 +10,8 @@ class Ultimate : public ControllerMode {
     Ultimate(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/Ultimate.hpp
+++ b/include/modes/Ultimate.hpp
@@ -1,11 +1,11 @@
 #ifndef _MODES_ULTIMATE_HPP
 #define _MODES_ULTIMATE_HPP
 
-#include "core/ControllerMode.hpp"
+#include "modes/PlatformFighter.hpp"
 #include "core/socd.hpp"
 #include "core/state.hpp"
 
-class Ultimate : public ControllerMode {
+class Ultimate : public PlatformFighter {
   public:
     Ultimate(socd::SocdType socd_type);
 

--- a/include/modes/extra/DarkSouls.hpp
+++ b/include/modes/extra/DarkSouls.hpp
@@ -10,8 +10,8 @@ class DarkSouls : public ControllerMode {
     DarkSouls(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/extra/DarkSouls.hpp
+++ b/include/modes/extra/DarkSouls.hpp
@@ -10,8 +10,8 @@ class DarkSouls : public ControllerMode {
     DarkSouls(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/extra/HollowKnight.hpp
+++ b/include/modes/extra/HollowKnight.hpp
@@ -11,8 +11,8 @@ class HollowKnight : public ControllerMode {
     HollowKnight(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/extra/HollowKnight.hpp
+++ b/include/modes/extra/HollowKnight.hpp
@@ -11,8 +11,8 @@ class HollowKnight : public ControllerMode {
     HollowKnight(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/extra/MKWii.hpp
+++ b/include/modes/extra/MKWii.hpp
@@ -10,8 +10,8 @@ class MKWii : public ControllerMode {
     MKWii(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/extra/MKWii.hpp
+++ b/include/modes/extra/MKWii.hpp
@@ -10,8 +10,8 @@ class MKWii : public ControllerMode {
     MKWii(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/extra/RocketLeague.hpp
+++ b/include/modes/extra/RocketLeague.hpp
@@ -10,9 +10,9 @@ class RocketLeague : public ControllerMode {
     RocketLeague(socd::SocdType socd_type);
 
   private:
-    void HandleSocd(InputState &inputs);
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void HandleSocd();
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/extra/RocketLeague.hpp
+++ b/include/modes/extra/RocketLeague.hpp
@@ -11,8 +11,8 @@ class RocketLeague : public ControllerMode {
 
   private:
     void HandleSocd(InputState &inputs);
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/extra/SaltAndSanctuary.hpp
+++ b/include/modes/extra/SaltAndSanctuary.hpp
@@ -10,8 +10,8 @@ class SaltAndSanctuary : public ControllerMode {
     SaltAndSanctuary(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/extra/SaltAndSanctuary.hpp
+++ b/include/modes/extra/SaltAndSanctuary.hpp
@@ -10,8 +10,8 @@ class SaltAndSanctuary : public ControllerMode {
     SaltAndSanctuary(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/extra/ShovelKnight.hpp
+++ b/include/modes/extra/ShovelKnight.hpp
@@ -10,8 +10,8 @@ class ShovelKnight : public ControllerMode {
     ShovelKnight(socd::SocdType socd_type);
 
   private:
-    virtual void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    virtual void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    virtual void UpdateDigitalOutputs(InputState &inputs);
+    virtual void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/extra/ShovelKnight.hpp
+++ b/include/modes/extra/ShovelKnight.hpp
@@ -10,8 +10,8 @@ class ShovelKnight : public ControllerMode {
     ShovelKnight(socd::SocdType socd_type);
 
   private:
-    virtual void UpdateDigitalOutputs(InputState &inputs);
-    virtual void UpdateAnalogOutputs(InputState &inputs);
+    virtual void UpdateDigitalOutputs();
+    virtual void UpdateAnalogOutputs();
 };
 
 #endif

--- a/include/modes/extra/Ultimate2.hpp
+++ b/include/modes/extra/Ultimate2.hpp
@@ -1,11 +1,11 @@
 #ifndef _MODES_ULTIMATE_HPP
 #define _MODES_ULTIMATE_HPP
 
-#include "core/ControllerMode.hpp"
+#include "modes/PlatformFighter.hpp"
 #include "core/socd.hpp"
 #include "core/state.hpp"
 
-class Ultimate2 : public ControllerMode {
+class Ultimate2 : public PlatformFighter {
   public:
     Ultimate2(socd::SocdType socd_type);
 

--- a/include/modes/extra/Ultimate2.hpp
+++ b/include/modes/extra/Ultimate2.hpp
@@ -1,5 +1,5 @@
-#ifndef _MODES_ULTIMATE_HPP
-#define _MODES_ULTIMATE_HPP
+#ifndef _MODES_ULTIMATE2_HPP
+#define _MODES_ULTIMATE2_HPP
 
 #include "modes/PlatformFighter.hpp"
 #include "core/socd.hpp"

--- a/include/modes/extra/Ultimate2.hpp
+++ b/include/modes/extra/Ultimate2.hpp
@@ -10,8 +10,8 @@ class Ultimate2 : public ControllerMode {
     Ultimate2(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
-    void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
+    void UpdateDigitalOutputs(InputState &inputs);
+    void UpdateAnalogOutputs(InputState &inputs);
 };
 
 #endif

--- a/include/modes/extra/Ultimate2.hpp
+++ b/include/modes/extra/Ultimate2.hpp
@@ -10,8 +10,8 @@ class Ultimate2 : public PlatformFighter {
     Ultimate2(socd::SocdType socd_type);
 
   private:
-    void UpdateDigitalOutputs(InputState &inputs);
-    void UpdateAnalogOutputs(InputState &inputs);
+    void UpdateDigitalOutputs();
+    void UpdateAnalogOutputs();
 };
 
 #endif

--- a/lib/TUComposite/src/TUGamepad.cpp
+++ b/lib/TUComposite/src/TUGamepad.cpp
@@ -47,10 +47,10 @@ bool TUGamepad::sendState() {
 
 void TUGamepad::resetInputs() {
     releaseAll();
-    leftXAxis(128);
-    leftYAxis(128);
-    rightXAxis(128);
-    rightYAxis(128);
+    leftXAxis(ANALOG_STICK_NEUTRAL);
+    leftYAxis(ANALOG_STICK_NEUTRAL);
+    rightXAxis(ANALOG_STICK_NEUTRAL);
+    rightYAxis(ANALOG_STICK_NEUTRAL);
     triggerLAnalog(0);
     triggerRAnalog(0);
 }

--- a/src/core/CommunicationBackend.cpp
+++ b/src/core/CommunicationBackend.cpp
@@ -36,7 +36,7 @@ void CommunicationBackend::ResetOutputs() {
 void CommunicationBackend::UpdateOutputs() {
     ResetOutputs();
     if (_gamemode != nullptr) {
-        _gamemode->UpdateOutputs(_inputs, _outputs);
+        _gamemode->UpdateOutputs(_inputs, &_outputs);
     }
 }
 

--- a/src/core/CommunicationBackend.cpp
+++ b/src/core/CommunicationBackend.cpp
@@ -36,7 +36,7 @@ void CommunicationBackend::ResetOutputs() {
 void CommunicationBackend::UpdateOutputs() {
     ResetOutputs();
     if (_gamemode != nullptr) {
-        _gamemode->UpdateOutputs(_inputs, &_outputs);
+        _gamemode->UpdateOutputs(&_inputs, &_outputs);
     }
 }
 

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -1,7 +1,7 @@
 #include "core/ControllerMode.hpp"
 
 ControllerMode::ControllerMode(socd::SocdType socd_type, uint8_t analog_stick_length) : InputMode(socd_type) {
-    this->_analog_stick_length = _analog_stick_length;
+    _analog_stick_length = analog_stick_length;
 
     // Set up initial state.
     ResetDirections();

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -8,16 +8,15 @@ ControllerMode::ControllerMode(socd::SocdType socd_type, uint8_t analog_stick_le
 }
 
 void ControllerMode::UpdateOutputs(InputState* inputs, OutputState* outputs) {
-    
-    HandleSocd(inputs);
+    _inputs = inputs;
+    _outputs = outputs;
 
-    if (outputs == nullptr)
+    if (inputs == nullptr || outputs == nullptr)
         return;
 
-    this->outputs = outputs;
-
-    UpdateDigitalOutputs(inputs);
-    UpdateAnalogOutputs(inputs);
+    HandleSocd();
+    UpdateDigitalOutputs();
+    UpdateAnalogOutputs();
 }
 
 void ControllerMode::ResetDirections() {
@@ -46,30 +45,30 @@ void ControllerMode::UpdateDirections(
     uint8_t analogStickMax = ANALOG_STICK_NEUTRAL + analog_stick_length;
     ResetDirections();
 
-    outputs->leftStickX = ANALOG_STICK_NEUTRAL;
-    outputs->leftStickY = ANALOG_STICK_NEUTRAL;
-    outputs->rightStickX = ANALOG_STICK_NEUTRAL;
-    outputs->rightStickY = ANALOG_STICK_NEUTRAL;
+    _outputs->leftStickX = ANALOG_STICK_NEUTRAL;
+    _outputs->leftStickY = ANALOG_STICK_NEUTRAL;
+    _outputs->rightStickX = ANALOG_STICK_NEUTRAL;
+    _outputs->rightStickY = ANALOG_STICK_NEUTRAL;
 
     // Coordinate calculations to make modifier handling simpler.
     if (lsLeft || lsRight) {
         directions.horizontal = true;
         if (lsLeft) {
             directions.x = -1;
-            outputs->leftStickX = analogStickMin;
+            _outputs->leftStickX = analogStickMin;
         } else {
             directions.x = 1;
-            outputs->leftStickX = analogStickMax;
+            _outputs->leftStickX = analogStickMax;
         }
     }
     if (lsDown || lsUp) {
         directions.vertical = true;
         if (lsDown) {
             directions.y = -1;
-            outputs->leftStickY = analogStickMin;
+            _outputs->leftStickY = analogStickMin;
         } else {
             directions.y = 1;
-            outputs->leftStickY = analogStickMax;
+            _outputs->leftStickY = analogStickMax;
         }
     }
     if (directions.horizontal && directions.vertical)
@@ -78,19 +77,19 @@ void ControllerMode::UpdateDirections(
     if (rsLeft || rsRight) {
         if (rsLeft) {
             directions.cx = -1;
-            outputs->rightStickX = analogStickMin;
+            _outputs->rightStickX = analogStickMin;
         } else {
             directions.cx = 1;
-            outputs->rightStickX = analogStickMax;
+            _outputs->rightStickX = analogStickMax;
         }
     }
     if (rsDown || rsUp) {
         if (rsDown) {
             directions.cy = -1;
-            outputs->rightStickY = analogStickMin;
+            _outputs->rightStickY = analogStickMin;
         } else {
             directions.cy = 1;
-            outputs->rightStickY = analogStickMax;
+            _outputs->rightStickY = analogStickMax;
         }
     }
 }
@@ -100,11 +99,11 @@ void ControllerMode::SetAxis(uint8_t* axis, const int8_t &direction, const uint1
 }
 
 void ControllerMode::SetLeftStickX(const uint16_t &value) {
-    SetAxis(&outputs->leftStickX, directions.x, value);
+    SetAxis(&_outputs->leftStickX, directions.x, value);
 }
 
 void ControllerMode::SetLeftStickY(const uint16_t &value) {
-    SetAxis(&outputs->leftStickY, directions.y, value);
+    SetAxis(&_outputs->leftStickY, directions.y, value);
 }
 
 void ControllerMode::SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue) {
@@ -113,9 +112,9 @@ void ControllerMode::SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDi
 }
 
 void ControllerMode::SetLeftStick(const uint16_t &xValue, const uint16_t &yValue) {
-    SetStick(&outputs->leftStickX, &outputs->leftStickY, directions.x, directions.y, xValue, yValue);
+    SetStick(&_outputs->leftStickX, &_outputs->leftStickY, directions.x, directions.y, xValue, yValue);
 }
 
 void ControllerMode::SetRightStick(const uint16_t &xValue, const uint16_t &yValue) {
-    SetStick(&outputs->rightStickX, &outputs->leftStickY, directions.x, directions.y, xValue, yValue);
+    SetStick(&_outputs->rightStickX, &_outputs->leftStickY, directions.x, directions.y, xValue, yValue);
 }

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -118,3 +118,7 @@ void ControllerMode::SetLeftStick(const uint16_t &xValue, const uint16_t &yValue
 void ControllerMode::SetRightStick(const uint16_t &xValue, const uint16_t &yValue) {
     SetStick(&_outputs->rightStickX, &_outputs->leftStickY, directions.x, directions.y, xValue, yValue);
 }
+
+void ControllerMode::SetAngledFSmash(const uint16_t &xValue, const uint16_t yValue) {
+    SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, xValue, yValue);
+}

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -89,7 +89,7 @@ void ControllerMode::UpdateDirections(
 }
 
 void ControllerMode::SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value) {
-    *axis = 128 + (direction * (uint8_t)(value / 125));
+    *axis = ANALOG_STICK_NEUTRAL + (direction * (uint8_t)(value / 125));
 }
 
 void ControllerMode::SetLeftStickX(OutputState &outputs, const uint16_t &value) {

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -1,6 +1,8 @@
 #include "core/ControllerMode.hpp"
 
-ControllerMode::ControllerMode(socd::SocdType socd_type) : InputMode(socd_type) {
+ControllerMode::ControllerMode(socd::SocdType socd_type, uint8_t analog_stick_length) : InputMode(socd_type) {
+    this->analog_stick_length = analog_stick_length;
+
     // Set up initial state.
     ResetDirections();
 }
@@ -32,17 +34,16 @@ void ControllerMode::UpdateDirections(
     bool rsRight,
     bool rsDown,
     bool rsUp,
-    uint8_t analogStickMin,
-    uint8_t analogStickNeutral,
-    uint8_t analogStickMax,
     OutputState &outputs
 ) {
+    uint8_t analogStickMin = ANALOG_STICK_NEUTRAL - analog_stick_length;
+    uint8_t analogStickMax = ANALOG_STICK_NEUTRAL + analog_stick_length;
     ResetDirections();
 
-    outputs.leftStickX = analogStickNeutral;
-    outputs.leftStickY = analogStickNeutral;
-    outputs.rightStickX = analogStickNeutral;
-    outputs.rightStickY = analogStickNeutral;
+    outputs.leftStickX = ANALOG_STICK_NEUTRAL;
+    outputs.leftStickY = ANALOG_STICK_NEUTRAL;
+    outputs.rightStickX = ANALOG_STICK_NEUTRAL;
+    outputs.rightStickY = ANALOG_STICK_NEUTRAL;
 
     // Coordinate calculations to make modifier handling simpler.
     if (lsLeft || lsRight) {
@@ -89,7 +90,7 @@ void ControllerMode::UpdateDirections(
 }
 
 void ControllerMode::SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value) {
-    *axis = ANALOG_STICK_NEUTRAL + (direction * (uint8_t)(value / 125));
+    *axis = ANALOG_STICK_NEUTRAL + direction * (uint8_t)(value / (10000 / analog_stick_length));
 }
 
 void ControllerMode::SetLeftStickX(OutputState &outputs, const uint16_t &value) {

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -7,10 +7,17 @@ ControllerMode::ControllerMode(socd::SocdType socd_type, uint8_t analog_stick_le
     ResetDirections();
 }
 
-void ControllerMode::UpdateOutputs(InputState &inputs, OutputState &outputs) {
+void ControllerMode::UpdateOutputs(InputState* inputs, OutputState* outputs) {
+    
     HandleSocd(inputs);
-    UpdateDigitalOutputs(inputs, outputs);
-    UpdateAnalogOutputs(inputs, outputs);
+
+    if (outputs == nullptr)
+        return;
+
+    this->outputs = outputs;
+
+    UpdateDigitalOutputs(inputs);
+    UpdateAnalogOutputs(inputs);
 }
 
 void ControllerMode::ResetDirections() {
@@ -33,37 +40,36 @@ void ControllerMode::UpdateDirections(
     bool rsLeft,
     bool rsRight,
     bool rsDown,
-    bool rsUp,
-    OutputState &outputs
+    bool rsUp
 ) {
     uint8_t analogStickMin = ANALOG_STICK_NEUTRAL - analog_stick_length;
     uint8_t analogStickMax = ANALOG_STICK_NEUTRAL + analog_stick_length;
     ResetDirections();
 
-    outputs.leftStickX = ANALOG_STICK_NEUTRAL;
-    outputs.leftStickY = ANALOG_STICK_NEUTRAL;
-    outputs.rightStickX = ANALOG_STICK_NEUTRAL;
-    outputs.rightStickY = ANALOG_STICK_NEUTRAL;
+    outputs->leftStickX = ANALOG_STICK_NEUTRAL;
+    outputs->leftStickY = ANALOG_STICK_NEUTRAL;
+    outputs->rightStickX = ANALOG_STICK_NEUTRAL;
+    outputs->rightStickY = ANALOG_STICK_NEUTRAL;
 
     // Coordinate calculations to make modifier handling simpler.
     if (lsLeft || lsRight) {
         directions.horizontal = true;
         if (lsLeft) {
             directions.x = -1;
-            outputs.leftStickX = analogStickMin;
+            outputs->leftStickX = analogStickMin;
         } else {
             directions.x = 1;
-            outputs.leftStickX = analogStickMax;
+            outputs->leftStickX = analogStickMax;
         }
     }
     if (lsDown || lsUp) {
         directions.vertical = true;
         if (lsDown) {
             directions.y = -1;
-            outputs.leftStickY = analogStickMin;
+            outputs->leftStickY = analogStickMin;
         } else {
             directions.y = 1;
-            outputs.leftStickY = analogStickMax;
+            outputs->leftStickY = analogStickMax;
         }
     }
     if (directions.horizontal && directions.vertical)
@@ -72,19 +78,19 @@ void ControllerMode::UpdateDirections(
     if (rsLeft || rsRight) {
         if (rsLeft) {
             directions.cx = -1;
-            outputs.rightStickX = analogStickMin;
+            outputs->rightStickX = analogStickMin;
         } else {
             directions.cx = 1;
-            outputs.rightStickX = analogStickMax;
+            outputs->rightStickX = analogStickMax;
         }
     }
     if (rsDown || rsUp) {
         if (rsDown) {
             directions.cy = -1;
-            outputs.rightStickY = analogStickMin;
+            outputs->rightStickY = analogStickMin;
         } else {
             directions.cy = 1;
-            outputs.rightStickY = analogStickMax;
+            outputs->rightStickY = analogStickMax;
         }
     }
 }
@@ -93,12 +99,12 @@ void ControllerMode::SetAxis(uint8_t* axis, const int8_t &direction, const uint1
     *axis = ANALOG_STICK_NEUTRAL + direction * (uint8_t)(value / (10000 / analog_stick_length));
 }
 
-void ControllerMode::SetLeftStickX(OutputState &outputs, const uint16_t &value) {
-    SetAxis(&outputs.leftStickX, directions.x, value);
+void ControllerMode::SetLeftStickX(const uint16_t &value) {
+    SetAxis(&outputs->leftStickX, directions.x, value);
 }
 
-void ControllerMode::SetLeftStickY(OutputState &outputs, const uint16_t &value) {
-    SetAxis(&outputs.leftStickY, directions.y, value);
+void ControllerMode::SetLeftStickY(const uint16_t &value) {
+    SetAxis(&outputs->leftStickY, directions.y, value);
 }
 
 void ControllerMode::SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue) {
@@ -106,10 +112,10 @@ void ControllerMode::SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDi
     SetAxis(yAxis, yDirection, yValue);
 }
 
-void ControllerMode::SetLeftStick(OutputState &outputs, const uint16_t &xValue, const uint16_t &yValue) {
-    SetStick(&outputs.leftStickX, &outputs.leftStickY, directions.x, directions.y, xValue, yValue);
+void ControllerMode::SetLeftStick(const uint16_t &xValue, const uint16_t &yValue) {
+    SetStick(&outputs->leftStickX, &outputs->leftStickY, directions.x, directions.y, xValue, yValue);
 }
 
-void ControllerMode::SetRightStick(OutputState &outputs, const uint16_t &xValue, const uint16_t &yValue) {
-    SetStick(&outputs.rightStickX, &outputs.leftStickY, directions.x, directions.y, xValue, yValue);
+void ControllerMode::SetRightStick(const uint16_t &xValue, const uint16_t &yValue) {
+    SetStick(&outputs->rightStickX, &outputs->leftStickY, directions.x, directions.y, xValue, yValue);
 }

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -1,7 +1,7 @@
 #include "core/ControllerMode.hpp"
 
 ControllerMode::ControllerMode(socd::SocdType socd_type, uint8_t analog_stick_length) : InputMode(socd_type) {
-    this->analog_stick_length = analog_stick_length;
+    this->_analog_stick_length = _analog_stick_length;
 
     // Set up initial state.
     ResetDirections();
@@ -41,8 +41,8 @@ void ControllerMode::UpdateDirections(
     bool rsDown,
     bool rsUp
 ) {
-    uint8_t analogStickMin = ANALOG_STICK_NEUTRAL - analog_stick_length;
-    uint8_t analogStickMax = ANALOG_STICK_NEUTRAL + analog_stick_length;
+    uint8_t analogStickMin = ANALOG_STICK_NEUTRAL - _analog_stick_length;
+    uint8_t analogStickMax = ANALOG_STICK_NEUTRAL + _analog_stick_length;
     ResetDirections();
 
     _outputs->leftStickX = ANALOG_STICK_NEUTRAL;
@@ -92,33 +92,4 @@ void ControllerMode::UpdateDirections(
             _outputs->rightStickY = analogStickMax;
         }
     }
-}
-
-void ControllerMode::SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value) {
-    *axis = ANALOG_STICK_NEUTRAL + direction * (uint8_t)(value / (10000 / analog_stick_length));
-}
-
-void ControllerMode::SetLeftStickX(const uint16_t &value) {
-    SetAxis(&_outputs->leftStickX, directions.x, value);
-}
-
-void ControllerMode::SetLeftStickY(const uint16_t &value) {
-    SetAxis(&_outputs->leftStickY, directions.y, value);
-}
-
-void ControllerMode::SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue) {
-    SetAxis(xAxis, xDirection, xValue);
-    SetAxis(yAxis, yDirection, yValue);
-}
-
-void ControllerMode::SetLeftStick(const uint16_t &xValue, const uint16_t &yValue) {
-    SetStick(&_outputs->leftStickX, &_outputs->leftStickY, directions.x, directions.y, xValue, yValue);
-}
-
-void ControllerMode::SetRightStick(const uint16_t &xValue, const uint16_t &yValue) {
-    SetStick(&_outputs->rightStickX, &_outputs->leftStickY, directions.x, directions.y, xValue, yValue);
-}
-
-void ControllerMode::SetAngledFSmash(const uint16_t &xValue, const uint16_t yValue) {
-    SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, xValue, yValue);
 }

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -87,3 +87,28 @@ void ControllerMode::UpdateDirections(
         }
     }
 }
+
+void ControllerMode::SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value) {
+    *axis = 128 + (direction * (uint8_t)(value / 125));
+}
+
+void ControllerMode::SetLeftStickX(OutputState &outputs, const StickDirections &directions, const uint16_t &value) {
+    SetAxis(&outputs.leftStickX, directions.x, value);
+}
+
+void ControllerMode::SetLeftStickY(OutputState &outputs, const StickDirections &directions, const uint16_t &value) {
+    SetAxis(&outputs.leftStickY, directions.y, value);
+}
+
+void ControllerMode::SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue) {
+    SetAxis(xAxis, xDirection, xValue);
+    SetAxis(yAxis, yDirection, yValue);
+}
+
+void ControllerMode::SetLeftStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue) {
+    SetStick(&outputs.leftStickX, &outputs.leftStickY, directions.x, directions.y, xValue, yValue);
+}
+
+void ControllerMode::SetRightStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue) {
+    SetStick(&outputs.rightStickX, &outputs.leftStickY, directions.x, directions.y, xValue, yValue);
+}

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -92,11 +92,11 @@ void ControllerMode::SetAxis(uint8_t* axis, const int8_t &direction, const uint1
     *axis = 128 + (direction * (uint8_t)(value / 125));
 }
 
-void ControllerMode::SetLeftStickX(OutputState &outputs, const StickDirections &directions, const uint16_t &value) {
+void ControllerMode::SetLeftStickX(OutputState &outputs, const uint16_t &value) {
     SetAxis(&outputs.leftStickX, directions.x, value);
 }
 
-void ControllerMode::SetLeftStickY(OutputState &outputs, const StickDirections &directions, const uint16_t &value) {
+void ControllerMode::SetLeftStickY(OutputState &outputs, const uint16_t &value) {
     SetAxis(&outputs.leftStickY, directions.y, value);
 }
 
@@ -105,10 +105,10 @@ void ControllerMode::SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDi
     SetAxis(yAxis, yDirection, yValue);
 }
 
-void ControllerMode::SetLeftStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue) {
+void ControllerMode::SetLeftStick(OutputState &outputs, const uint16_t &xValue, const uint16_t &yValue) {
     SetStick(&outputs.leftStickX, &outputs.leftStickY, directions.x, directions.y, xValue, yValue);
 }
 
-void ControllerMode::SetRightStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue) {
+void ControllerMode::SetRightStick(OutputState &outputs, const uint16_t &xValue, const uint16_t &yValue) {
     SetStick(&outputs.rightStickX, &outputs.leftStickY, directions.x, directions.y, xValue, yValue);
 }

--- a/src/core/InputMode.cpp
+++ b/src/core/InputMode.cpp
@@ -12,7 +12,7 @@ InputMode::~InputMode() {
     delete[] _socd_states;
 }
 
-void InputMode::HandleSocd(InputState &inputs) {
+void InputMode::HandleSocd() {
     if (_socd_pairs == nullptr) {
         return;
     }
@@ -27,15 +27,15 @@ void InputMode::HandleSocd(InputState &inputs) {
         socd::SocdPair pair = _socd_pairs[i];
         switch (_socd_type) {
             case socd::SOCD_NEUTRAL:
-                socd::neutral(inputs.*(pair.input_dir1), inputs.*(pair.input_dir2));
+                socd::neutral(_inputs->*(pair.input_dir1), _inputs->*(pair.input_dir2));
                 break;
             case socd::SOCD_2IP:
-                socd::twoIP(inputs.*(pair.input_dir1), inputs.*(pair.input_dir2), _socd_states[i]);
+                socd::twoIP(_inputs->*(pair.input_dir1), _inputs->*(pair.input_dir2), _socd_states[i]);
                 break;
             case socd::SOCD_2IP_NO_REAC:
                 socd::twoIPNoReactivate(
-                    inputs.*(pair.input_dir1),
-                    inputs.*(pair.input_dir2),
+                    _inputs->*(pair.input_dir1),
+                    _inputs->*(pair.input_dir2),
                     _socd_states[i]
                 );
                 break;

--- a/src/modes/FgcMode.cpp
+++ b/src/modes/FgcMode.cpp
@@ -40,6 +40,8 @@ void FgcMode::UpdateDigitalOutputs() {
 }
 
 void FgcMode::UpdateAnalogOutputs() {
-    SetLeftStick(0000, 0000);
-    SetRightStick(0000, 0000);
+    _outputs->leftStickX = ANALOG_STICK_NEUTRAL;
+    _outputs->leftStickY = ANALOG_STICK_NEUTRAL;
+    _outputs->rightStickX = ANALOG_STICK_NEUTRAL;
+    _outputs->rightStickY = ANALOG_STICK_NEUTRAL;
 }

--- a/src/modes/FgcMode.cpp
+++ b/src/modes/FgcMode.cpp
@@ -7,39 +7,39 @@ FgcMode::FgcMode(socd::SocdType socd_type) : ControllerMode(socd_type) {
     };
 }
 
-void FgcMode::HandleSocd(InputState &inputs) {
-    if (inputs.down && (inputs.mod_x || inputs.c_up)) {
-        inputs.down = false;
+void FgcMode::HandleSocd() {
+    if (_inputs->down && (_inputs->mod_x || _inputs->c_up)) {
+        _inputs->down = false;
     }
-    InputMode::HandleSocd(inputs);
+    InputMode::HandleSocd();
 }
 
-void FgcMode::UpdateDigitalOutputs(InputState &inputs) {
+void FgcMode::UpdateDigitalOutputs() {
     // Directions
-    outputs->dpadLeft = inputs.left;
-    outputs->dpadRight = inputs.right;
-    outputs->dpadDown = inputs.down;
-    outputs->dpadUp = inputs.mod_x || inputs.c_up;
+    _outputs->dpadLeft = _inputs->left;
+    _outputs->dpadRight = _inputs->right;
+    _outputs->dpadDown = _inputs->down;
+    _outputs->dpadUp = _inputs->mod_x || _inputs->c_up;
 
     // Menu keys
-    outputs->start = inputs.start;
-    outputs->select = inputs.c_left;
-    outputs->home = inputs.c_down;
+    _outputs->start = _inputs->start;
+    _outputs->select = _inputs->c_left;
+    _outputs->home = _inputs->c_down;
 
     // Right hand bottom row
-    outputs->a = inputs.b;
-    outputs->b = inputs.x;
-    outputs->triggerRDigital = inputs.z;
-    outputs->triggerLDigital = inputs.up;
+    _outputs->a = _inputs->b;
+    _outputs->b = _inputs->x;
+    _outputs->triggerRDigital = _inputs->z;
+    _outputs->triggerLDigital = _inputs->up;
 
     // Right hand top row
-    outputs->x = inputs.r;
-    outputs->y = inputs.y;
-    outputs->buttonR = inputs.lightshield;
-    outputs->buttonL = inputs.midshield;
+    _outputs->x = _inputs->r;
+    _outputs->y = _inputs->y;
+    _outputs->buttonR = _inputs->lightshield;
+    _outputs->buttonL = _inputs->midshield;
 }
 
-void FgcMode::UpdateAnalogOutputs(InputState &inputs) {
+void FgcMode::UpdateAnalogOutputs() {
     SetLeftStick(0000, 0000);
     SetRightStick(0000, 0000);
 }

--- a/src/modes/FgcMode.cpp
+++ b/src/modes/FgcMode.cpp
@@ -40,8 +40,6 @@ void FgcMode::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
 }
 
 void FgcMode::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.leftStickX = 128;
-    outputs.leftStickY = 128;
-    outputs.rightStickX = 128;
-    outputs.rightStickY = 128;
+    SetLeftStick(outputs, 0000, 0000);
+    SetRightStick(outputs, 0000, 0000);
 }

--- a/src/modes/FgcMode.cpp
+++ b/src/modes/FgcMode.cpp
@@ -14,32 +14,32 @@ void FgcMode::HandleSocd(InputState &inputs) {
     InputMode::HandleSocd(inputs);
 }
 
-void FgcMode::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
+void FgcMode::UpdateDigitalOutputs(InputState &inputs) {
     // Directions
-    outputs.dpadLeft = inputs.left;
-    outputs.dpadRight = inputs.right;
-    outputs.dpadDown = inputs.down;
-    outputs.dpadUp = inputs.mod_x || inputs.c_up;
+    outputs->dpadLeft = inputs.left;
+    outputs->dpadRight = inputs.right;
+    outputs->dpadDown = inputs.down;
+    outputs->dpadUp = inputs.mod_x || inputs.c_up;
 
     // Menu keys
-    outputs.start = inputs.start;
-    outputs.select = inputs.c_left;
-    outputs.home = inputs.c_down;
+    outputs->start = inputs.start;
+    outputs->select = inputs.c_left;
+    outputs->home = inputs.c_down;
 
     // Right hand bottom row
-    outputs.a = inputs.b;
-    outputs.b = inputs.x;
-    outputs.triggerRDigital = inputs.z;
-    outputs.triggerLDigital = inputs.up;
+    outputs->a = inputs.b;
+    outputs->b = inputs.x;
+    outputs->triggerRDigital = inputs.z;
+    outputs->triggerLDigital = inputs.up;
 
     // Right hand top row
-    outputs.x = inputs.r;
-    outputs.y = inputs.y;
-    outputs.buttonR = inputs.lightshield;
-    outputs.buttonL = inputs.midshield;
+    outputs->x = inputs.r;
+    outputs->y = inputs.y;
+    outputs->buttonR = inputs.lightshield;
+    outputs->buttonL = inputs.midshield;
 }
 
-void FgcMode::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
-    SetLeftStick(outputs, 0000, 0000);
-    SetRightStick(outputs, 0000, 0000);
+void FgcMode::UpdateAnalogOutputs(InputState &inputs) {
+    SetLeftStick(0000, 0000);
+    SetRightStick(0000, 0000);
 }

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -1,21 +1,7 @@
 #include "modes/Melee18Button.hpp"
 
-Melee18Button::Melee18Button(socd::SocdType socd_type) : ControllerMode(socd_type, 80) {
-    _socd_pair_count = 4;
-    _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
-    };
-
-    horizontal_socd = false;
-}
-
-void Melee18Button::HandleSocd() {
-    horizontal_socd = _inputs->left && _inputs->right;
-    InputMode::HandleSocd();
-}
+Melee18Button::Melee18Button(socd::SocdType socd_type)
+    : PlatformFighter(socd_type, 80) { }
 
 void Melee18Button::UpdateDigitalOutputs() {
     _outputs->a = _inputs->a;
@@ -214,7 +200,7 @@ void Melee18Button::UpdateAnalogOutputs() {
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
-    if (!_inputs->r && horizontal_socd && !directions.vertical) {
+    if (!_inputs->r && _horizontal_socd && !directions.vertical) {
         SetLeftStickX(10000);
     }
 

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -17,39 +17,39 @@ void Melee18Button::HandleSocd(InputState &inputs) {
     InputMode::HandleSocd(inputs);
 }
 
-void Melee18Button::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.a = inputs.a;
-    outputs.b = inputs.b;
-    outputs.x = inputs.x;
-    outputs.y = inputs.y;
-    outputs.buttonR = inputs.z;
+void Melee18Button::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->a = inputs.a;
+    outputs->b = inputs.b;
+    outputs->x = inputs.x;
+    outputs->y = inputs.y;
+    outputs->buttonR = inputs.z;
     if (inputs.nunchuk_connected) {
         // Lightshield with C button.
         if (inputs.nunchuk_c) {
-            outputs.triggerLAnalog = 49;
+            outputs->triggerLAnalog = 49;
         }
-        outputs.triggerLDigital = inputs.nunchuk_z;
+        outputs->triggerLDigital = inputs.nunchuk_z;
     } else {
-        outputs.triggerLDigital = inputs.l;
+        outputs->triggerLDigital = inputs.l;
     }
-    outputs.triggerRDigital = inputs.r;
-    outputs.start = inputs.start;
+    outputs->triggerRDigital = inputs.r;
+    outputs->start = inputs.start;
 
     /********* DPAD *********/
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.dpadUp = inputs.c_up;
-        outputs.dpadDown = inputs.c_down;
-        outputs.dpadLeft = inputs.c_left;
-        outputs.dpadRight = inputs.c_right;
+        outputs->dpadUp = inputs.c_up;
+        outputs->dpadDown = inputs.c_down;
+        outputs->dpadLeft = inputs.c_left;
+        outputs->dpadRight = inputs.c_right;
     }
 
     if (inputs.select)
-        outputs.dpadLeft = true;
+        outputs->dpadLeft = true;
     if (inputs.home)
-        outputs.dpadRight = true;
+        outputs->dpadRight = true;
 }
 
-void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void Melee18Button::UpdateAnalogOutputs(InputState &inputs) {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
         inputs.left,
@@ -59,55 +59,54 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 
     bool shield_button_pressed = inputs.l || inputs.r;
 
     if (inputs.mod_x) {
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 6625);
+            SetLeftStickX(6625);
         }
         if (directions.vertical) {
-            SetLeftStickY(outputs, 2875);
+            SetLeftStickY(2875);
         }
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
+            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 7375, 3125); // 22.9638°
+            SetLeftStick(7375, 3125); // 22.9638°
             if (inputs.c_down) {
-                SetLeftStick(outputs, 7000, 3625); // 27.37104°
+                SetLeftStick(7000, 3625); // 27.37104°
             }
             if (inputs.c_left) {
-                SetLeftStick(outputs, 7875, 4875); // 31.77828°
+                SetLeftStick(7875, 4875); // 31.77828°
             }
             if (inputs.c_up) {
-                SetLeftStick(outputs, 7000, 5125); // 36.18552°
+                SetLeftStick(7000, 5125); // 36.18552°
             }
             if (inputs.c_right) {
-                SetLeftStick(outputs, 6125, 5250); // 40.59276°
+                SetLeftStick(6125, 5250); // 40.59276°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                SetLeftStick(outputs, 9125, 3875); // 22.9638°
+                SetLeftStick(9125, 3875); // 22.9638°
                 if (inputs.c_down) {
-                    SetLeftStick(outputs, 8750, 4500); // 27.37104°
+                    SetLeftStick(8750, 4500); // 27.37104°
                 }
                 if (inputs.c_left) {
-                    SetLeftStick(outputs, 8500, 5250); // 31.77828°
+                    SetLeftStick(8500, 5250); // 31.77828°
                 }
                 if (inputs.c_up) {
-                    SetLeftStick(outputs, 7375, 5375); // 36.18552°
+                    SetLeftStick(7375, 5375); // 36.18552°
                 }
                 if (inputs.c_right) {
-                    SetLeftStick(outputs, 6375, 5375); // 40.59276°
+                    SetLeftStick(6375, 5375); // 40.59276°
                 }
             }
         }
@@ -115,47 +114,47 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     if (inputs.mod_y) {
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 3375);
+            SetLeftStickX(3375);
         }
         if (directions.vertical) {
-            SetLeftStickY(outputs, 7375);
+            SetLeftStickY(7375);
         }
 
         // Turnaround neutral B nerf
         if (inputs.b) {
-            SetLeftStickX(outputs, 10000);
+            SetLeftStickX(10000);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 3125, 7375); // 67.03623°
+            SetLeftStick(3125, 7375); // 67.03623°
             if (inputs.c_down) {
-                SetLeftStick(outputs, 3625, 7000); // 62.62896°
+                SetLeftStick(3625, 7000); // 62.62896°
             }
             if (inputs.c_left) {
-                SetLeftStick(outputs, 4875, 7875); // 58.22172°
+                SetLeftStick(4875, 7875); // 58.22172°
             }
             if (inputs.c_up) {
-                SetLeftStick(outputs, 5125, 7000); // 53.81448°
+                SetLeftStick(5125, 7000); // 53.81448°
             }
             if (inputs.c_right) {
-                SetLeftStick(outputs, 6375, 7625); // 49.40724°
+                SetLeftStick(6375, 7625); // 49.40724°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                SetLeftStick(outputs, 3875, 9125); // 67.0362°
+                SetLeftStick(3875, 9125); // 67.0362°
                 if (inputs.c_down) {
-                    SetLeftStick(outputs, 4500, 8750); // 62.62896°
+                    SetLeftStick(4500, 8750); // 62.62896°
                 }
                 if (inputs.c_left) {
-                    SetLeftStick(outputs, 5250, 8500); // 58.22172°
+                    SetLeftStick(5250, 8500); // 58.22172°
                 }
                 if (inputs.c_up) {
-                    SetLeftStick(outputs, 5875, 8000); // 53.81448°
+                    SetLeftStick(5875, 8000); // 53.81448°
                 }
                 if (inputs.c_right) {
-                    SetLeftStick(outputs, 5875, 7125); // 49.40724°
+                    SetLeftStick(5875, 7125); // 49.40724°
                 }
             }
         }
@@ -163,27 +162,27 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     if (inputs.l) {
         if (directions.horizontal)
-            SetLeftStickX(outputs, 10000);
+            SetLeftStickX(10000);
         if (directions.vertical)
-            SetLeftStickY(outputs, 10000);
+            SetLeftStickY(10000);
         if (directions.horizontal && directions.y > 0) {
-            SetLeftStick(outputs, 5375, 5375); // 45°
+            SetLeftStick(5375, 5375); // 45°
         }
         if (directions.horizontal && directions.y < 0) {
-            SetLeftStick(outputs, 7125, 6875); // 43.97697°
+            SetLeftStick(7125, 6875); // 43.97697°
         }
         if (inputs.mod_x || inputs.mod_y) {
             if (!(inputs.mod_x && inputs.mod_y)) {
-                outputs.triggerLDigital = false;
-                outputs.triggerRAnalog = 49;
+                outputs->triggerLDigital = false;
+                outputs->triggerRAnalog = 49;
             }
 
             if (directions.diagonal) {
                 if (inputs.mod_x) {
-                    SetLeftStick(outputs, 6375, 3750); // 30.46554°
+                    SetLeftStick(6375, 3750); // 30.46554°
                 }
                 if (inputs.mod_y) {
-                    SetLeftStick(outputs, 5000, 8500); // 59.53446°
+                    SetLeftStick(5000, 8500); // 59.53446°
                 }
             }
         }
@@ -191,18 +190,18 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     if (inputs.r) {
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 6375);
+            SetLeftStickX(6375);
         }
         if (directions.vertical) {
-            SetLeftStickY(outputs, 5375);
+            SetLeftStickY(5375);
         }
         if (directions.diagonal) {
-            SetLeftStickX(outputs, 5375);
+            SetLeftStickX(5375);
             if (inputs.mod_x) {
-                SetLeftStick(outputs, 6375, 3750); // 30.46554°
+                SetLeftStick(6375, 3750); // 30.46554°
             }
             if (inputs.mod_y) {
-                SetLeftStick(outputs, 5000, 8500); // 59.53446°
+                SetLeftStick(5000, 8500); // 59.53446°
             }
         }
     }
@@ -210,23 +209,23 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        SetRightStick(outputs, 5250, 8500); // 58.29857°
+        SetRightStick(5250, 8500); // 58.29857°
     }
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
     if (!inputs.r && horizontal_socd && !directions.vertical) {
-        SetLeftStickX(outputs, 10000);
+        SetLeftStickX(10000);
     }
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        SetRightStick(outputs, 0000, 0000); // 0°
+        SetRightStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs.leftStickX = inputs.nunchuk_x;
-        outputs.leftStickY = inputs.nunchuk_y;
+        outputs->leftStickX = inputs.nunchuk_x;
+        outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -74,7 +74,7 @@ void Melee18Button::UpdateAnalogOutputs() {
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
+            SetAngledFSmash(8500, 5250); // 31.70143°
         }
 
         /* Up B angles */

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -1,7 +1,6 @@
 #include "modes/Melee18Button.hpp"
 
 #define ANALOG_STICK_MIN 48
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 208
 
 Melee18Button::Melee18Button(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -228,7 +228,7 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        SetRightStick(outputs, 0000, 0000);
+        SetRightStick(outputs, 0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -74,69 +74,47 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     if (inputs.mod_x) {
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 53);
+            SetLeftStickX(outputs, 6625);
         }
         if (directions.vertical) {
-            outputs.leftStickY = 128 + (directions.y * 23);
+            SetLeftStickY(outputs, 2875);
         }
 
         // Angled fsmash
         if (directions.cx != 0) {
-            // 8500 5250 = 68 42
-            outputs.rightStickX = 128 + (directions.cx * 68);
-            outputs.rightStickY = 128 + (directions.y * 42);
+            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            // 22.9638 - 7375 3125 = 59 25
-            outputs.leftStickX = 128 + (directions.x * 59);
-            outputs.leftStickY = 128 + (directions.y * 25);
-            // 27.37104 - 7000 3625 (27.38) = 56 29
+            SetLeftStick(outputs, 7375, 3125); // 22.9638°
             if (inputs.c_down) {
-                outputs.leftStickX = 128 + (directions.x * 56);
-                outputs.leftStickY = 128 + (directions.y * 29);
+                SetLeftStick(outputs, 7000, 3625); // 27.37104°
             }
-            // 31.77828 - 7875 4875 (31.76) = 63 39
             if (inputs.c_left) {
-                outputs.leftStickX = 128 + (directions.x * 63);
-                outputs.leftStickY = 128 + (directions.y * 39);
+                SetLeftStick(outputs, 7875, 4875); // 31.77828°
             }
-            // 36.18552 - 7000 5125 (36.21) = 56 41
             if (inputs.c_up) {
-                outputs.leftStickX = 128 + (directions.x * 56);
-                outputs.leftStickY = 128 + (directions.y * 41);
+                SetLeftStick(outputs, 7000, 5125); // 36.18552°
             }
-            // 40.59276 - 6125 5250 (40.6) = 49 42
             if (inputs.c_right) {
-                outputs.leftStickX = 128 + (directions.x * 49);
-                outputs.leftStickY = 128 + (directions.y * 42);
+                SetLeftStick(outputs, 6125, 5250); // 40.59276°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                // 22.9638 - 9125 3875 (23.0) = 73 31
-                outputs.leftStickX = 128 + (directions.x * 73);
-                outputs.leftStickY = 128 + (directions.y * 31);
-                // 27.37104 - 8750 4500 (27.2) = 70 36
+                SetLeftStick(outputs, 9125, 3875); // 22.9638°
                 if (inputs.c_down) {
-                    outputs.leftStickX = 128 + (directions.x * 70);
-                    outputs.leftStickY = 128 + (directions.y * 36);
+                    SetLeftStick(outputs, 8750, 4500); // 27.37104°
                 }
-                // 31.77828 - 8500 5250 (31.7) = 68 42
                 if (inputs.c_left) {
-                    outputs.leftStickX = 128 + (directions.x * 68);
-                    outputs.leftStickY = 128 + (directions.y * 42);
+                    SetLeftStick(outputs, 8500, 5250); // 31.77828°
                 }
-                // 36.18552 - 7375 5375 (36.1) = 59 43
                 if (inputs.c_up) {
-                    outputs.leftStickX = 128 + (directions.x * 59);
-                    outputs.leftStickY = 128 + (directions.y * 43);
+                    SetLeftStick(outputs, 7375, 5375); // 36.18552°
                 }
-                // 40.59276 - 6375 5375 (40.1) = 51 43
                 if (inputs.c_right) {
-                    outputs.leftStickX = 128 + (directions.x * 51);
-                    outputs.leftStickY = 128 + (directions.y * 43);
+                    SetLeftStick(outputs, 6375, 5375); // 40.59276°
                 }
             }
         }
@@ -144,67 +122,47 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     if (inputs.mod_y) {
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 27);
+            SetLeftStickX(outputs, 3375);
         }
         if (directions.vertical) {
-            outputs.leftStickY = 128 + (directions.y * 59);
+            SetLeftStickY(outputs, 7375);
         }
 
         // Turnaround neutral B nerf
         if (inputs.b) {
-            outputs.leftStickX = 128 + (directions.x * 80);
+            SetLeftStickX(outputs, 10000);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            // 67.0362 - 3125 7375 = 25 59
-            outputs.leftStickX = 128 + (directions.x * 25);
-            outputs.leftStickY = 128 + (directions.y * 59);
-            // 62.62896 - 3625 7000 (62.62) = 29 56
+            SetLeftStick(outputs, 3125, 7375); // 67.03623°
             if (inputs.c_down) {
-                outputs.leftStickX = 128 + (directions.x * 29);
-                outputs.leftStickY = 128 + (directions.y * 56);
+                SetLeftStick(outputs, 3625, 7000); // 62.62896°
             }
-            // 58.22172 - 4875 7875 (58.24) = 39 63
             if (inputs.c_left) {
-                outputs.leftStickX = 128 + (directions.x * 39);
-                outputs.leftStickY = 128 + (directions.y * 63);
+                SetLeftStick(outputs, 4875, 7875); // 58.22172°
             }
-            // 53.81448 - 5125 7000 (53.79) = 41 56
             if (inputs.c_up) {
-                outputs.leftStickX = 128 + (directions.x * 41);
-                outputs.leftStickY = 128 + (directions.y * 56);
+                SetLeftStick(outputs, 5125, 7000); // 53.81448°
             }
-            // 49.40724 - 6375 7625 (50.10) = 51 61
             if (inputs.c_right) {
-                outputs.leftStickX = 128 + (directions.x * 51);
-                outputs.leftStickY = 128 + (directions.y * 61);
+                SetLeftStick(outputs, 6375, 7625); // 49.40724°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                // 67.0362 - 3875 9125 = 31 73
-                outputs.leftStickX = 128 + (directions.x * 31);
-                outputs.leftStickY = 128 + (directions.y * 73);
-                // 62.62896 - 4500 8750 (62.8) = 36 70
+                SetLeftStick(outputs, 3875, 9125); // 67.0362°
                 if (inputs.c_down) {
-                    outputs.leftStickX = 128 + (directions.x * 36);
-                    outputs.leftStickY = 128 + (directions.y * 70);
+                    SetLeftStick(outputs, 4500, 8750); // 62.62896°
                 }
-                // 58.22172 - 5250 8500 (58.3) = 42 68
                 if (inputs.c_left) {
-                    outputs.leftStickX = 128 + (directions.x * 42);
-                    outputs.leftStickY = 128 + (directions.y * 68);
+                    SetLeftStick(outputs, 5250, 8500); // 58.22172°
                 }
-                // 53.81448 - 5875 8000 (53.7) = 47 64
                 if (inputs.c_up) {
-                    outputs.leftStickX = 128 + (directions.x * 47);
-                    outputs.leftStickY = 128 + (directions.y * 64);
+                    SetLeftStick(outputs, 5875, 8000); // 53.81448°
                 }
-                // 49.40724 - 5875 7125 (50.49) = 47 57
                 if (inputs.c_right) {
-                    outputs.leftStickX = 128 + (directions.x * 47);
-                    outputs.leftStickY = 128 + (directions.y * 57);
+                    SetLeftStick(outputs, 5875, 7125); // 49.40724°
                 }
             }
         }
@@ -212,16 +170,14 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     if (inputs.l) {
         if (directions.horizontal)
-            outputs.leftStickX = 128 + (directions.x * 100);
+            SetLeftStickX(outputs, 10000);
         if (directions.vertical)
-            outputs.leftStickY = 128 + (directions.y * 100);
-        if (directions.horizontal && (directions.y == 1)) {
-            outputs.leftStickX = 128 + (directions.x * 43);
-            outputs.leftStickY = 128 + 43;
+            SetLeftStickY(outputs, 10000);
+        if (directions.horizontal && directions.y > 0) {
+            SetLeftStick(outputs, 5375, 5375); // 45°
         }
-        if (directions.horizontal && (directions.y == -1)) {
-            outputs.leftStickX = 128 + (directions.x * 57);
-            outputs.leftStickY = 128 - 55;
+        if (directions.horizontal && directions.y < 0) {
+            SetLeftStick(outputs, 7125, 6875); // 43.97697°
         }
         if (inputs.mod_x || inputs.mod_y) {
             if (!(inputs.mod_x && inputs.mod_y)) {
@@ -231,12 +187,10 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
             if (directions.diagonal) {
                 if (inputs.mod_x) {
-                    outputs.leftStickX = 128 + (directions.x * 51);
-                    outputs.leftStickY = 128 + (directions.y * 30);
+                    SetLeftStick(outputs, 6375, 3750); // 30.46554°
                 }
                 if (inputs.mod_y) {
-                    outputs.leftStickX = 128 + (directions.x * 40);
-                    outputs.leftStickY = 128 + (directions.y * 68);
+                    SetLeftStick(outputs, 5000, 8500); // 59.53446°
                 }
             }
         }
@@ -244,20 +198,18 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     if (inputs.r) {
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 51);
+            SetLeftStickX(outputs, 6375);
         }
         if (directions.vertical) {
-            outputs.leftStickY = 128 + (directions.y * 43);
+            SetLeftStickY(outputs, 5375);
         }
         if (directions.diagonal) {
-            outputs.leftStickX = 128 + (directions.x * 43);
+            SetLeftStickX(outputs, 5375);
             if (inputs.mod_x) {
-                outputs.leftStickX = 128 + (directions.x * 51);
-                outputs.leftStickY = 128 + (directions.y * 30);
+                SetLeftStick(outputs, 6375, 3750); // 30.46554°
             }
             if (inputs.mod_y) {
-                outputs.leftStickX = 128 + (directions.x * 40);
-                outputs.leftStickY = 128 + (directions.y * 68);
+                SetLeftStick(outputs, 5000, 8500); // 59.53446°
             }
         }
     }
@@ -265,21 +217,18 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        // 5250 8500 = 42 68
-        outputs.rightStickX = 128 + (directions.cx * 42);
-        outputs.rightStickY = 128 + (directions.cy * 68);
+        SetRightStick(outputs, 5250, 8500); // 58.29857°
     }
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
     if (!inputs.r && horizontal_socd && !directions.vertical) {
-        outputs.leftStickX = 128 + (directions.x * 80);
+        SetLeftStickX(outputs, 10000);
     }
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = 128;
-        outputs.rightStickY = 128;
+        SetRightStick(outputs, 0000, 0000);
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -185,7 +185,7 @@ void Melee18Button::UpdateAnalogOutputs() {
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        SetRightStick(5250, 8500); // 58.29857°
+        SetCStick(5250, 8500); // 58.29857°
     }
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
@@ -196,7 +196,7 @@ void Melee18Button::UpdateAnalogOutputs() {
 
     // Shut off c-stick when using dpad layer.
     if (_inputs->mod_x && _inputs->mod_y) {
-        SetRightStick(0000, 0000); // 0°
+        SetCStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -1,8 +1,6 @@
 #include "modes/Melee18Button.hpp"
 
-#define ANALOG_STICK_LENGTH 80
-
-Melee18Button::Melee18Button(socd::SocdType socd_type) : ControllerMode(socd_type) {
+Melee18Button::Melee18Button(socd::SocdType socd_type) : ControllerMode(socd_type, 80) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
         socd::SocdPair{&InputState::left,    &InputState::right  },
@@ -62,9 +60,6 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -36,17 +36,7 @@ void Melee18Button::UpdateDigitalOutputs() {
 }
 
 void Melee18Button::UpdateAnalogOutputs() {
-    // Coordinate calculations to make modifier handling simpler.
-    UpdateDirections(
-        _inputs->left,
-        _inputs->right,
-        _inputs->down,
-        _inputs->up,
-        _inputs->c_left,
-        _inputs->c_right,
-        _inputs->c_down,
-        _inputs->c_up
-    );
+    UpdateDirections();
 
     bool shield_button_pressed = _inputs->l || _inputs->r;
 

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -1,7 +1,6 @@
 #include "modes/Melee18Button.hpp"
 
-#define ANALOG_STICK_MIN 48
-#define ANALOG_STICK_MAX 208
+#define ANALOG_STICK_LENGTH 80
 
 Melee18Button::Melee18Button(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -12,59 +12,59 @@ Melee18Button::Melee18Button(socd::SocdType socd_type) : ControllerMode(socd_typ
     horizontal_socd = false;
 }
 
-void Melee18Button::HandleSocd(InputState &inputs) {
-    horizontal_socd = inputs.left && inputs.right;
-    InputMode::HandleSocd(inputs);
+void Melee18Button::HandleSocd() {
+    horizontal_socd = _inputs->left && _inputs->right;
+    InputMode::HandleSocd();
 }
 
-void Melee18Button::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->a = inputs.a;
-    outputs->b = inputs.b;
-    outputs->x = inputs.x;
-    outputs->y = inputs.y;
-    outputs->buttonR = inputs.z;
-    if (inputs.nunchuk_connected) {
+void Melee18Button::UpdateDigitalOutputs() {
+    _outputs->a = _inputs->a;
+    _outputs->b = _inputs->b;
+    _outputs->x = _inputs->x;
+    _outputs->y = _inputs->y;
+    _outputs->buttonR = _inputs->z;
+    if (_inputs->nunchuk_connected) {
         // Lightshield with C button.
-        if (inputs.nunchuk_c) {
-            outputs->triggerLAnalog = 49;
+        if (_inputs->nunchuk_c) {
+            _outputs->triggerLAnalog = 49;
         }
-        outputs->triggerLDigital = inputs.nunchuk_z;
+        _outputs->triggerLDigital = _inputs->nunchuk_z;
     } else {
-        outputs->triggerLDigital = inputs.l;
+        _outputs->triggerLDigital = _inputs->l;
     }
-    outputs->triggerRDigital = inputs.r;
-    outputs->start = inputs.start;
+    _outputs->triggerRDigital = _inputs->r;
+    _outputs->start = _inputs->start;
 
     /********* DPAD *********/
-    if (inputs.mod_x && inputs.mod_y) {
-        outputs->dpadUp = inputs.c_up;
-        outputs->dpadDown = inputs.c_down;
-        outputs->dpadLeft = inputs.c_left;
-        outputs->dpadRight = inputs.c_right;
+    if (_inputs->mod_x && _inputs->mod_y) {
+        _outputs->dpadUp = _inputs->c_up;
+        _outputs->dpadDown = _inputs->c_down;
+        _outputs->dpadLeft = _inputs->c_left;
+        _outputs->dpadRight = _inputs->c_right;
     }
 
-    if (inputs.select)
-        outputs->dpadLeft = true;
-    if (inputs.home)
-        outputs->dpadRight = true;
+    if (_inputs->select)
+        _outputs->dpadLeft = true;
+    if (_inputs->home)
+        _outputs->dpadRight = true;
 }
 
-void Melee18Button::UpdateAnalogOutputs(InputState &inputs) {
+void Melee18Button::UpdateAnalogOutputs() {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.up,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->up,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 
-    bool shield_button_pressed = inputs.l || inputs.r;
+    bool shield_button_pressed = _inputs->l || _inputs->r;
 
-    if (inputs.mod_x) {
+    if (_inputs->mod_x) {
         if (directions.horizontal) {
             SetLeftStickX(6625);
         }
@@ -74,45 +74,45 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs) {
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
+            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             SetLeftStick(7375, 3125); // 22.9638°
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(7000, 3625); // 27.37104°
             }
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(7875, 4875); // 31.77828°
             }
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(7000, 5125); // 36.18552°
             }
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(6125, 5250); // 40.59276°
             }
 
             /* Extended Up B Angles */
-            if (inputs.b) {
+            if (_inputs->b) {
                 SetLeftStick(9125, 3875); // 22.9638°
-                if (inputs.c_down) {
+                if (_inputs->c_down) {
                     SetLeftStick(8750, 4500); // 27.37104°
                 }
-                if (inputs.c_left) {
+                if (_inputs->c_left) {
                     SetLeftStick(8500, 5250); // 31.77828°
                 }
-                if (inputs.c_up) {
+                if (_inputs->c_up) {
                     SetLeftStick(7375, 5375); // 36.18552°
                 }
-                if (inputs.c_right) {
+                if (_inputs->c_right) {
                     SetLeftStick(6375, 5375); // 40.59276°
                 }
             }
         }
     }
 
-    if (inputs.mod_y) {
+    if (_inputs->mod_y) {
         if (directions.horizontal) {
             SetLeftStickX(3375);
         }
@@ -121,46 +121,46 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs) {
         }
 
         // Turnaround neutral B nerf
-        if (inputs.b) {
+        if (_inputs->b) {
             SetLeftStickX(10000);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             SetLeftStick(3125, 7375); // 67.03623°
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(3625, 7000); // 62.62896°
             }
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(4875, 7875); // 58.22172°
             }
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(5125, 7000); // 53.81448°
             }
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(6375, 7625); // 49.40724°
             }
 
             /* Extended Up B Angles */
-            if (inputs.b) {
+            if (_inputs->b) {
                 SetLeftStick(3875, 9125); // 67.0362°
-                if (inputs.c_down) {
+                if (_inputs->c_down) {
                     SetLeftStick(4500, 8750); // 62.62896°
                 }
-                if (inputs.c_left) {
+                if (_inputs->c_left) {
                     SetLeftStick(5250, 8500); // 58.22172°
                 }
-                if (inputs.c_up) {
+                if (_inputs->c_up) {
                     SetLeftStick(5875, 8000); // 53.81448°
                 }
-                if (inputs.c_right) {
+                if (_inputs->c_right) {
                     SetLeftStick(5875, 7125); // 49.40724°
                 }
             }
         }
     }
 
-    if (inputs.l) {
+    if (_inputs->l) {
         if (directions.horizontal)
             SetLeftStickX(10000);
         if (directions.vertical)
@@ -171,24 +171,24 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs) {
         if (directions.horizontal && directions.y < 0) {
             SetLeftStick(7125, 6875); // 43.97697°
         }
-        if (inputs.mod_x || inputs.mod_y) {
-            if (!(inputs.mod_x && inputs.mod_y)) {
-                outputs->triggerLDigital = false;
-                outputs->triggerRAnalog = 49;
+        if (_inputs->mod_x || _inputs->mod_y) {
+            if (!(_inputs->mod_x && _inputs->mod_y)) {
+                _outputs->triggerLDigital = false;
+                _outputs->triggerRAnalog = 49;
             }
 
             if (directions.diagonal) {
-                if (inputs.mod_x) {
+                if (_inputs->mod_x) {
                     SetLeftStick(6375, 3750); // 30.46554°
                 }
-                if (inputs.mod_y) {
+                if (_inputs->mod_y) {
                     SetLeftStick(5000, 8500); // 59.53446°
                 }
             }
         }
     }
 
-    if (inputs.r) {
+    if (_inputs->r) {
         if (directions.horizontal) {
             SetLeftStickX(6375);
         }
@@ -197,10 +197,10 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs) {
         }
         if (directions.diagonal) {
             SetLeftStickX(5375);
-            if (inputs.mod_x) {
+            if (_inputs->mod_x) {
                 SetLeftStick(6375, 3750); // 30.46554°
             }
-            if (inputs.mod_y) {
+            if (_inputs->mod_y) {
                 SetLeftStick(5000, 8500); // 59.53446°
             }
         }
@@ -214,18 +214,18 @@ void Melee18Button::UpdateAnalogOutputs(InputState &inputs) {
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
-    if (!inputs.r && horizontal_socd && !directions.vertical) {
+    if (!_inputs->r && horizontal_socd && !directions.vertical) {
         SetLeftStickX(10000);
     }
 
     // Shut off c-stick when using dpad layer.
-    if (inputs.mod_x && inputs.mod_y) {
+    if (_inputs->mod_x && _inputs->mod_y) {
         SetRightStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.
-    if (inputs.nunchuk_connected) {
-        outputs->leftStickX = inputs.nunchuk_x;
-        outputs->leftStickY = inputs.nunchuk_y;
+    if (_inputs->nunchuk_connected) {
+        _outputs->leftStickX = _inputs->nunchuk_x;
+        _outputs->leftStickY = _inputs->nunchuk_y;
     }
 }

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -12,54 +12,54 @@ Melee20Button::Melee20Button(socd::SocdType socd_type) : ControllerMode(socd_typ
     horizontal_socd = false;
 }
 
-void Melee20Button::HandleSocd(InputState &inputs) {
-    horizontal_socd = inputs.left && inputs.right;
-    InputMode::HandleSocd(inputs);
+void Melee20Button::HandleSocd() {
+    horizontal_socd = _inputs->left && _inputs->right;
+    InputMode::HandleSocd();
 }
 
-void Melee20Button::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->a = inputs.a;
-    outputs->b = inputs.b;
-    outputs->x = inputs.x;
-    outputs->y = inputs.y;
-    outputs->buttonR = inputs.z;
-    if (inputs.nunchuk_connected) {
-        outputs->triggerLDigital = inputs.nunchuk_z;
+void Melee20Button::UpdateDigitalOutputs() {
+    _outputs->a = _inputs->a;
+    _outputs->b = _inputs->b;
+    _outputs->x = _inputs->x;
+    _outputs->y = _inputs->y;
+    _outputs->buttonR = _inputs->z;
+    if (_inputs->nunchuk_connected) {
+        _outputs->triggerLDigital = _inputs->nunchuk_z;
     } else {
-        outputs->triggerLDigital = inputs.l;
+        _outputs->triggerLDigital = _inputs->l;
     }
-    outputs->triggerRDigital = inputs.r;
-    outputs->start = inputs.start;
+    _outputs->triggerRDigital = _inputs->r;
+    _outputs->start = _inputs->start;
 
     // D-Pad layer can be activated by holding Mod X + Mod Y, or by holding the C
     // button on a nunchuk.
-    if ((inputs.mod_x && inputs.mod_y) || inputs.nunchuk_c) {
-        outputs->dpadUp = inputs.c_up;
-        outputs->dpadDown = inputs.c_down;
-        outputs->dpadLeft = inputs.c_left;
-        outputs->dpadRight = inputs.c_right;
+    if ((_inputs->mod_x && _inputs->mod_y) || _inputs->nunchuk_c) {
+        _outputs->dpadUp = _inputs->c_up;
+        _outputs->dpadDown = _inputs->c_down;
+        _outputs->dpadLeft = _inputs->c_left;
+        _outputs->dpadRight = _inputs->c_right;
     }
 
-    if (inputs.select)
-        outputs->dpadLeft = true;
-    if (inputs.home)
-        outputs->dpadRight = true;
+    if (_inputs->select)
+        _outputs->dpadLeft = true;
+    if (_inputs->home)
+        _outputs->dpadRight = true;
 }
 
-void Melee20Button::UpdateAnalogOutputs(InputState &inputs) {
+void Melee20Button::UpdateAnalogOutputs() {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.up,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->up,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 
-    bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
+    bool shield_button_pressed = _inputs->l || _inputs->r || _inputs->lightshield || _inputs->midshield;
     if (directions.diagonal) {
         // L, R, LS, and MS + q1/2
         SetLeftStick(7000, 7000); // 45°
@@ -70,7 +70,7 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs) {
         }
     }
 
-    if (inputs.mod_x) {
+    if (_inputs->mod_x) {
         // MX + Horizontal (even if shield is held)
         if (directions.horizontal) {
             SetLeftStickX(6625);
@@ -89,45 +89,45 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs) {
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
+            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             SetLeftStick(7375, 3125); // 22.9638°
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(7000, 3625); // 27.37104°
             }
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(7875, 4875); // 31.77828°
             }
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(7000, 5125); // 36.18552°
             }
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(6125, 5250); // 40.59276°
             }
 
             /* Extended Up B Angles */
-            if (inputs.b) {
+            if (_inputs->b) {
                 SetLeftStick(9125, 3875); // 22.9638°
-                if (inputs.c_down) {
+                if (_inputs->c_down) {
                     SetLeftStick(8750, 4500); // 27.37104°
                 }
-                if (inputs.c_left) {
+                if (_inputs->c_left) {
                     SetLeftStick(8500, 5250); // 31.77828°
                 }
-                if (inputs.c_up) {
+                if (_inputs->c_up) {
                     SetLeftStick(7375, 5375); // 36.18552°
                 }
-                if (inputs.c_right) {
+                if (_inputs->c_right) {
                     SetLeftStick(6375, 5375); // 40.59276°
                 }
             }
         }
     }
 
-    if (inputs.mod_y) {
+    if (_inputs->mod_y) {
         // MY + Horizontal (even if shield is held)
         if (directions.horizontal) {
             SetLeftStickX(3375);
@@ -147,39 +147,39 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs) {
         }
 
         // Turnaround neutral B nerf
-        if (inputs.b) {
+        if (_inputs->b) {
             SetLeftStickX(10000);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             SetLeftStick(3125, 7375); // 67.03623°
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(3625, 7000); // 62.62896°
             }
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(4875, 7875); // 58.22172°
             }
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(5125, 7000); // 53.81448°
             }
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(6375, 7625); // 49.40724°
             }
 
             /* Extended Up B Angles */
-            if (inputs.b) {
+            if (_inputs->b) {
                 SetLeftStick(3875, 9125); // 67.0362°
-                if (inputs.c_down) {
+                if (_inputs->c_down) {
                     SetLeftStick(4500, 8750); // 62.62896°
                 }
-                if (inputs.c_left) {
+                if (_inputs->c_left) {
                     SetLeftStick(5250, 8500); // 58.22172°
                 }
-                if (inputs.c_up) {
+                if (_inputs->c_up) {
                     SetLeftStick(5875, 8000); // 53.81448°
                 }
-                if (inputs.c_right) {
+                if (_inputs->c_right) {
                     SetLeftStick(5875, 7125); // 49.40724°
                 }
             }
@@ -198,29 +198,29 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs) {
         SetLeftStickX(10000);
     }
 
-    if (inputs.lightshield) {
-        outputs->triggerRAnalog = 49;
+    if (_inputs->lightshield) {
+        _outputs->triggerRAnalog = 49;
     }
-    if (inputs.midshield) {
-        outputs->triggerRAnalog = 94;
-    }
-
-    if (outputs->triggerLDigital) {
-        outputs->triggerLAnalog = 140;
+    if (_inputs->midshield) {
+        _outputs->triggerRAnalog = 94;
     }
 
-    if (outputs->triggerRDigital) {
-        outputs->triggerRAnalog = 140;
+    if (_outputs->triggerLDigital) {
+        _outputs->triggerLAnalog = 140;
+    }
+
+    if (_outputs->triggerRDigital) {
+        _outputs->triggerRAnalog = 140;
     }
 
     // Shut off c-stick when using dpad layer.
-    if (inputs.mod_x && inputs.mod_y) {
+    if (_inputs->mod_x && _inputs->mod_y) {
         SetRightStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.
-    if (inputs.nunchuk_connected) {
-        outputs->leftStickX = inputs.nunchuk_x;
-        outputs->leftStickY = inputs.nunchuk_y;
+    if (_inputs->nunchuk_connected) {
+        _outputs->leftStickX = _inputs->nunchuk_x;
+        _outputs->leftStickY = _inputs->nunchuk_y;
     }
 }

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -1,8 +1,6 @@
 #include "modes/Melee20Button.hpp"
 
-#define ANALOG_STICK_LENGTH 80
-
-Melee20Button::Melee20Button(socd::SocdType socd_type) : ControllerMode(socd_type) {
+Melee20Button::Melee20Button(socd::SocdType socd_type) : ControllerMode(socd_type, 80) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
         socd::SocdPair{&InputState::left,    &InputState::right  },
@@ -59,9 +57,6 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -33,17 +33,7 @@ void Melee20Button::UpdateDigitalOutputs() {
 }
 
 void Melee20Button::UpdateAnalogOutputs() {
-    // Coordinate calculations to make modifier handling simpler.
-    UpdateDirections(
-        _inputs->left,
-        _inputs->right,
-        _inputs->down,
-        _inputs->up,
-        _inputs->c_left,
-        _inputs->c_right,
-        _inputs->c_down,
-        _inputs->c_up
-    );
+    UpdateDirections();
 
     bool shield_button_pressed = _inputs->l || _inputs->r || _inputs->lightshield || _inputs->midshield;
     if (directions.diagonal) {

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -17,36 +17,36 @@ void Melee20Button::HandleSocd(InputState &inputs) {
     InputMode::HandleSocd(inputs);
 }
 
-void Melee20Button::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.a = inputs.a;
-    outputs.b = inputs.b;
-    outputs.x = inputs.x;
-    outputs.y = inputs.y;
-    outputs.buttonR = inputs.z;
+void Melee20Button::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->a = inputs.a;
+    outputs->b = inputs.b;
+    outputs->x = inputs.x;
+    outputs->y = inputs.y;
+    outputs->buttonR = inputs.z;
     if (inputs.nunchuk_connected) {
-        outputs.triggerLDigital = inputs.nunchuk_z;
+        outputs->triggerLDigital = inputs.nunchuk_z;
     } else {
-        outputs.triggerLDigital = inputs.l;
+        outputs->triggerLDigital = inputs.l;
     }
-    outputs.triggerRDigital = inputs.r;
-    outputs.start = inputs.start;
+    outputs->triggerRDigital = inputs.r;
+    outputs->start = inputs.start;
 
     // D-Pad layer can be activated by holding Mod X + Mod Y, or by holding the C
     // button on a nunchuk.
     if ((inputs.mod_x && inputs.mod_y) || inputs.nunchuk_c) {
-        outputs.dpadUp = inputs.c_up;
-        outputs.dpadDown = inputs.c_down;
-        outputs.dpadLeft = inputs.c_left;
-        outputs.dpadRight = inputs.c_right;
+        outputs->dpadUp = inputs.c_up;
+        outputs->dpadDown = inputs.c_down;
+        outputs->dpadLeft = inputs.c_left;
+        outputs->dpadRight = inputs.c_right;
     }
 
     if (inputs.select)
-        outputs.dpadLeft = true;
+        outputs->dpadLeft = true;
     if (inputs.home)
-        outputs.dpadRight = true;
+        outputs->dpadRight = true;
 }
 
-void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void Melee20Button::UpdateAnalogOutputs(InputState &inputs) {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
         inputs.left,
@@ -56,73 +56,72 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 
     bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
     if (directions.diagonal) {
         // L, R, LS, and MS + q1/2
-        SetLeftStick(outputs, 7000, 7000); // 45°
+        SetLeftStick(7000, 7000); // 45°
 
         // L, R, LS, and MS + q3/4 = Vanilla shield drop
         if (directions.y < 0 && shield_button_pressed) {
-            SetLeftStick(outputs, 7000, 6875); // 44.48384°
+            SetLeftStick(7000, 6875); // 44.48384°
         }
     }
 
     if (inputs.mod_x) {
         // MX + Horizontal (even if shield is held)
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 6625);
+            SetLeftStickX(6625);
         }
         // MX + Vertical (even if shield is held)
         if (directions.vertical) {
-            SetLeftStickY(outputs, 5375);
+            SetLeftStickY(5375);
         }
         if (directions.diagonal) {
             // MX + q1/2/3/4
-            SetLeftStick(outputs, 7375, 3125); // 22.96377°
+            SetLeftStick(7375, 3125); // 22.96377°
             if (shield_button_pressed) {
-                SetLeftStick(outputs, 6375, 3750); // 30.46554°
+                SetLeftStick(6375, 3750); // 30.46554°
             }
         }
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
+            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 7375, 3125); // 22.9638°
+            SetLeftStick(7375, 3125); // 22.9638°
             if (inputs.c_down) {
-                SetLeftStick(outputs, 7000, 3625); // 27.37104°
+                SetLeftStick(7000, 3625); // 27.37104°
             }
             if (inputs.c_left) {
-                SetLeftStick(outputs, 7875, 4875); // 31.77828°
+                SetLeftStick(7875, 4875); // 31.77828°
             }
             if (inputs.c_up) {
-                SetLeftStick(outputs, 7000, 5125); // 36.18552°
+                SetLeftStick(7000, 5125); // 36.18552°
             }
             if (inputs.c_right) {
-                SetLeftStick(outputs, 6125, 5250); // 40.59276°
+                SetLeftStick(6125, 5250); // 40.59276°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                SetLeftStick(outputs, 9125, 3875); // 22.9638°
+                SetLeftStick(9125, 3875); // 22.9638°
                 if (inputs.c_down) {
-                    SetLeftStick(outputs, 8750, 4500); // 27.37104°
+                    SetLeftStick(8750, 4500); // 27.37104°
                 }
                 if (inputs.c_left) {
-                    SetLeftStick(outputs, 8500, 5250); // 31.77828°
+                    SetLeftStick(8500, 5250); // 31.77828°
                 }
                 if (inputs.c_up) {
-                    SetLeftStick(outputs, 7375, 5375); // 36.18552°
+                    SetLeftStick(7375, 5375); // 36.18552°
                 }
                 if (inputs.c_right) {
-                    SetLeftStick(outputs, 6375, 5375); // 40.59276°
+                    SetLeftStick(6375, 5375); // 40.59276°
                 }
             }
         }
@@ -131,57 +130,57 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
     if (inputs.mod_y) {
         // MY + Horizontal (even if shield is held)
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 3375);
+            SetLeftStickX(3375);
         }
         // MY + Vertical (even if shield is held)
         if (directions.vertical) {
-            SetLeftStickY(outputs, 7375);
+            SetLeftStickY(7375);
         }
         if (directions.diagonal) {
-            SetLeftStick(outputs, 3125, 7375); // 67.03623°
+            SetLeftStick(3125, 7375); // 67.03623°
             if (shield_button_pressed) {
-                SetLeftStick(outputs, 4750, 8750); // 61.50436°
+                SetLeftStick(4750, 8750); // 61.50436°
                 if (directions.y < 0) {
-                    SetLeftStick(outputs, 5000, 8500); // 59.53446°
+                    SetLeftStick(5000, 8500); // 59.53446°
                 }
             }
         }
 
         // Turnaround neutral B nerf
         if (inputs.b) {
-            SetLeftStickX(outputs, 10000);
+            SetLeftStickX(10000);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 3125, 7375); // 67.03623°
+            SetLeftStick(3125, 7375); // 67.03623°
             if (inputs.c_down) {
-                SetLeftStick(outputs, 3625, 7000); // 62.62896°
+                SetLeftStick(3625, 7000); // 62.62896°
             }
             if (inputs.c_left) {
-                SetLeftStick(outputs, 4875, 7875); // 58.22172°
+                SetLeftStick(4875, 7875); // 58.22172°
             }
             if (inputs.c_up) {
-                SetLeftStick(outputs, 5125, 7000); // 53.81448°
+                SetLeftStick(5125, 7000); // 53.81448°
             }
             if (inputs.c_right) {
-                SetLeftStick(outputs, 6375, 7625); // 49.40724°
+                SetLeftStick(6375, 7625); // 49.40724°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                SetLeftStick(outputs, 3875, 9125); // 67.0362°
+                SetLeftStick(3875, 9125); // 67.0362°
                 if (inputs.c_down) {
-                    SetLeftStick(outputs, 4500, 8750); // 62.62896°
+                    SetLeftStick(4500, 8750); // 62.62896°
                 }
                 if (inputs.c_left) {
-                    SetLeftStick(outputs, 5250, 8500); // 58.22172°
+                    SetLeftStick(5250, 8500); // 58.22172°
                 }
                 if (inputs.c_up) {
-                    SetLeftStick(outputs, 5875, 8000); // 53.81448°
+                    SetLeftStick(5875, 8000); // 53.81448°
                 }
                 if (inputs.c_right) {
-                    SetLeftStick(outputs, 5875, 7125); // 49.40724°
+                    SetLeftStick(5875, 7125); // 49.40724°
                 }
             }
         }
@@ -190,38 +189,38 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        SetRightStick(outputs, 5250, 8500); // 58.29857°
+        SetRightStick(5250, 8500); // 58.29857°
     }
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
     if (horizontal_socd && !directions.vertical) {
-        SetLeftStickX(outputs, 10000);
+        SetLeftStickX(10000);
     }
 
     if (inputs.lightshield) {
-        outputs.triggerRAnalog = 49;
+        outputs->triggerRAnalog = 49;
     }
     if (inputs.midshield) {
-        outputs.triggerRAnalog = 94;
+        outputs->triggerRAnalog = 94;
     }
 
-    if (outputs.triggerLDigital) {
-        outputs.triggerLAnalog = 140;
+    if (outputs->triggerLDigital) {
+        outputs->triggerLAnalog = 140;
     }
 
-    if (outputs.triggerRDigital) {
-        outputs.triggerRAnalog = 140;
+    if (outputs->triggerRDigital) {
+        outputs->triggerRAnalog = 140;
     }
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        SetRightStick(outputs, 0000, 0000); // 0°
+        SetRightStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs.leftStickX = inputs.nunchuk_x;
-        outputs.leftStickY = inputs.nunchuk_y;
+        outputs->leftStickX = inputs.nunchuk_x;
+        outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -91,9 +91,7 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
             // MX + q1/2/3/4
             SetLeftStick(outputs, 7375, 3125); // 22.96377°
             if (shield_button_pressed) {
-                // MX + L, R, LS, and MS + q1/2/3/4 = 6375 3750 = 51 30
-                outputs.leftStickX = 128 + (directions.x * 51);
-                outputs.leftStickY = 128 + (directions.y * 30);
+                SetLeftStick(outputs, 6375, 3750); // 30.46554°
             }
         }
 

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -1,7 +1,6 @@
 #include "modes/Melee20Button.hpp"
 
 #define ANALOG_STICK_MIN 48
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 208
 
 Melee20Button::Melee20Button(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -1,7 +1,6 @@
 #include "modes/Melee20Button.hpp"
 
-#define ANALOG_STICK_MIN 48
-#define ANALOG_STICK_MAX 208
+#define ANALOG_STICK_LENGTH 80
 
 Melee20Button::Melee20Button(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -165,7 +165,7 @@ void Melee20Button::UpdateAnalogOutputs() {
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        SetRightStick(5250, 8500); // 58.29857°
+        SetCStick(5250, 8500); // 58.29857°
     }
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
@@ -191,7 +191,7 @@ void Melee20Button::UpdateAnalogOutputs() {
 
     // Shut off c-stick when using dpad layer.
     if (_inputs->mod_x && _inputs->mod_y) {
-        SetRightStick(0000, 0000); // 0°
+        SetCStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -89,7 +89,7 @@ void Melee20Button::UpdateAnalogOutputs() {
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 8500, 5250); // 31.70143°
+            SetAngledFSmash(8500, 5250); // 31.70143°
         }
 
         /* Up B angles */

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -70,26 +70,26 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
     bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
     if (directions.diagonal) {
         // L, R, LS, and MS + q1/2
-        SetLeftStick(outputs, directions, 7000, 7000); // 45°
+        SetLeftStick(outputs, 7000, 7000); // 45°
 
         // L, R, LS, and MS + q3/4 = Vanilla shield drop
         if (directions.y < 0 && shield_button_pressed) {
-            SetLeftStick(outputs, directions, 7000, 6875); // 44.48384°
+            SetLeftStick(outputs, 7000, 6875); // 44.48384°
         }
     }
 
     if (inputs.mod_x) {
         // MX + Horizontal (even if shield is held)
         if (directions.horizontal) {
-            SetLeftStickX(outputs, directions, 6625);
+            SetLeftStickX(outputs, 6625);
         }
         // MX + Vertical (even if shield is held)
         if (directions.vertical) {
-            SetLeftStickY(outputs, directions, 5375);
+            SetLeftStickY(outputs, 5375);
         }
         if (directions.diagonal) {
             // MX + q1/2/3/4
-            SetLeftStick(outputs, directions, 7375, 3125); // 22.96377°
+            SetLeftStick(outputs, 7375, 3125); // 22.96377°
             if (shield_button_pressed) {
                 // MX + L, R, LS, and MS + q1/2/3/4 = 6375 3750 = 51 30
                 outputs.leftStickX = 128 + (directions.x * 51);
@@ -104,34 +104,34 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, directions, 7375, 3125); // 22.9638°
+            SetLeftStick(outputs, 7375, 3125); // 22.9638°
             if (inputs.c_down) {
-                SetLeftStick(outputs, directions, 7000, 3625); // 27.37104°
+                SetLeftStick(outputs, 7000, 3625); // 27.37104°
             }
             if (inputs.c_left) {
-                SetLeftStick(outputs, directions, 7875, 4875); // 31.77828°
+                SetLeftStick(outputs, 7875, 4875); // 31.77828°
             }
             if (inputs.c_up) {
-                SetLeftStick(outputs, directions, 7000, 5125); // 36.18552°
+                SetLeftStick(outputs, 7000, 5125); // 36.18552°
             }
             if (inputs.c_right) {
-                SetLeftStick(outputs, directions, 6125, 5250); // 40.59276°
+                SetLeftStick(outputs, 6125, 5250); // 40.59276°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                SetLeftStick(outputs, directions, 9125, 3875); // 22.9638°
+                SetLeftStick(outputs, 9125, 3875); // 22.9638°
                 if (inputs.c_down) {
-                    SetLeftStick(outputs, directions, 8750, 4500); // 27.37104°
+                    SetLeftStick(outputs, 8750, 4500); // 27.37104°
                 }
                 if (inputs.c_left) {
-                    SetLeftStick(outputs, directions, 8500, 5250); // 31.77828°
+                    SetLeftStick(outputs, 8500, 5250); // 31.77828°
                 }
                 if (inputs.c_up) {
-                    SetLeftStick(outputs, directions, 7375, 5375); // 36.18552°
+                    SetLeftStick(outputs, 7375, 5375); // 36.18552°
                 }
                 if (inputs.c_right) {
-                    SetLeftStick(outputs, directions, 6375, 5375); // 40.59276°
+                    SetLeftStick(outputs, 6375, 5375); // 40.59276°
                 }
             }
         }
@@ -140,57 +140,57 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
     if (inputs.mod_y) {
         // MY + Horizontal (even if shield is held)
         if (directions.horizontal) {
-            SetLeftStickX(outputs, directions, 3375);
+            SetLeftStickX(outputs, 3375);
         }
         // MY + Vertical (even if shield is held)
         if (directions.vertical) {
-            SetLeftStickY(outputs, directions, 7375);
+            SetLeftStickY(outputs, 7375);
         }
         if (directions.diagonal) {
-            SetLeftStick(outputs, directions, 3125, 7375); // 67.03623°
+            SetLeftStick(outputs, 3125, 7375); // 67.03623°
             if (shield_button_pressed) {
-                SetLeftStick(outputs, directions, 4750, 8750); // 61.50436°
+                SetLeftStick(outputs, 4750, 8750); // 61.50436°
                 if (directions.y < 0) {
-                    SetLeftStick(outputs, directions, 5000, 8500); // 59.53446°
+                    SetLeftStick(outputs, 5000, 8500); // 59.53446°
                 }
             }
         }
 
         // Turnaround neutral B nerf
         if (inputs.b) {
-            SetLeftStickX(outputs, directions, 10000);
+            SetLeftStickX(outputs, 10000);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, directions, 3125, 7375); // 67.03623°
+            SetLeftStick(outputs, 3125, 7375); // 67.03623°
             if (inputs.c_down) {
-                SetLeftStick(outputs, directions, 3625, 7000); // 62.62896°
+                SetLeftStick(outputs, 3625, 7000); // 62.62896°
             }
             if (inputs.c_left) {
-                SetLeftStick(outputs, directions, 4875, 7875); // 58.22172°
+                SetLeftStick(outputs, 4875, 7875); // 58.22172°
             }
             if (inputs.c_up) {
-                SetLeftStick(outputs, directions, 5125, 7000); // 53.81448°
+                SetLeftStick(outputs, 5125, 7000); // 53.81448°
             }
             if (inputs.c_right) {
-                SetLeftStick(outputs, directions, 6375, 7625); // 49.40724°
+                SetLeftStick(outputs, 6375, 7625); // 49.40724°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                SetLeftStick(outputs, directions, 3875, 9125); // 67.0362°
+                SetLeftStick(outputs, 3875, 9125); // 67.0362°
                 if (inputs.c_down) {
-                    SetLeftStick(outputs, directions, 4500, 8750); // 62.62896°
+                    SetLeftStick(outputs, 4500, 8750); // 62.62896°
                 }
                 if (inputs.c_left) {
-                    SetLeftStick(outputs, directions, 5250, 8500); // 58.22172°
+                    SetLeftStick(outputs, 5250, 8500); // 58.22172°
                 }
                 if (inputs.c_up) {
-                    SetLeftStick(outputs, directions, 5875, 8000); // 53.81448°
+                    SetLeftStick(outputs, 5875, 8000); // 53.81448°
                 }
                 if (inputs.c_right) {
-                    SetLeftStick(outputs, directions, 5875, 7125); // 49.40724°
+                    SetLeftStick(outputs, 5875, 7125); // 49.40724°
                 }
             }
         }
@@ -199,13 +199,13 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        SetRightStick(outputs, directions, 5250, 8500); // 58.29857°
+        SetRightStick(outputs, 5250, 8500); // 58.29857°
     }
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
     if (horizontal_socd && !directions.vertical) {
-        SetLeftStickX(outputs, directions, 10000);
+        SetLeftStickX(outputs, 10000);
     }
 
     if (inputs.lightshield) {
@@ -225,7 +225,7 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        SetRightStick(outputs, directions, 0000, 0000);
+        SetRightStick(outputs, 0000, 0000);
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -223,7 +223,7 @@ void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        SetRightStick(outputs, 0000, 0000);
+        SetRightStick(outputs, 0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -50,31 +50,6 @@ void Melee20Button::UpdateDigitalOutputs(InputState &inputs, OutputState &output
         outputs.dpadRight = true;
 }
 
-void SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value) {
-    *axis = 128 + (direction * (uint8_t)(value / 125));
-}
-
-void SetLeftStickX(OutputState &outputs, const StickDirections &directions, const uint16_t &value) {
-    SetAxis(&outputs.leftStickX, directions.x, value);
-}
-
-void SetLeftStickY(OutputState &outputs, const StickDirections &directions, const uint16_t &value) {
-    SetAxis(&outputs.leftStickY, directions.y, value);
-}
-
-void SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue) {
-    SetAxis(xAxis, xDirection, xValue);
-    SetAxis(yAxis, yDirection, yValue);
-}
-
-void SetLeftStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue) {
-    SetStick(&outputs.leftStickX, &outputs.leftStickY, directions.x, directions.y, xValue, yValue);
-}
-
-void SetRightStick(OutputState &outputs, const StickDirections &directions, const uint16_t &xValue, const uint16_t &yValue) {
-    SetStick(&outputs.rightStickX, &outputs.leftStickY, directions.x, directions.y, xValue, yValue);
-}
-
 void Melee20Button::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -1,21 +1,7 @@
 #include "modes/Melee20Button.hpp"
 
-Melee20Button::Melee20Button(socd::SocdType socd_type) : ControllerMode(socd_type, 80) {
-    _socd_pair_count = 4;
-    _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
-    };
-
-    horizontal_socd = false;
-}
-
-void Melee20Button::HandleSocd() {
-    horizontal_socd = _inputs->left && _inputs->right;
-    InputMode::HandleSocd();
-}
+Melee20Button::Melee20Button(socd::SocdType socd_type) 
+    : PlatformFighter(socd_type, 80) { }
 
 void Melee20Button::UpdateDigitalOutputs() {
     _outputs->a = _inputs->a;
@@ -194,7 +180,7 @@ void Melee20Button::UpdateAnalogOutputs() {
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
-    if (horizontal_socd && !directions.vertical) {
+    if (_horizontal_socd && !directions.vertical) {
         SetLeftStickX(10000);
     }
 

--- a/src/modes/PlatformFighter.cpp
+++ b/src/modes/PlatformFighter.cpp
@@ -4,7 +4,7 @@ PlatformFighter::PlatformFighter(socd::SocdType socd_type, uint8_t analog_stick_
     : ControllerMode(socd_type, analog_stick_length) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{ &InputState::left,    &InputState::right },
+        socd::SocdPair{ &InputState::left,   &InputState::right  },
         socd::SocdPair{ &InputState::down,   &InputState::up     },
         socd::SocdPair{ &InputState::c_left, &InputState::c_right},
         socd::SocdPair{ &InputState::c_down, &InputState::c_up   },

--- a/src/modes/PlatformFighter.cpp
+++ b/src/modes/PlatformFighter.cpp
@@ -13,7 +13,36 @@ PlatformFighter::PlatformFighter(socd::SocdType socd_type, uint8_t analog_stick_
     _horizontal_socd = false;
 }
 
+void PlatformFighter::SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value) {
+    *axis = ANALOG_STICK_NEUTRAL + direction * (uint8_t)(value / (10000 / _analog_stick_length));
+}
+
 void PlatformFighter::HandleSocd() {
     _horizontal_socd = _inputs->left && _inputs->right;
     InputMode::HandleSocd();
+}
+
+void PlatformFighter::SetLeftStickX(const uint16_t &value) {
+    SetAxis(&_outputs->leftStickX, directions.x, value);
+}
+
+void PlatformFighter::SetLeftStickY(const uint16_t &value) {
+    SetAxis(&_outputs->leftStickY, directions.y, value);
+}
+
+void PlatformFighter::SetStick(uint8_t* xAxis, uint8_t* yAxis, const uint8_t &xDirection, const uint8_t &yDirection, const uint16_t &xValue, const uint16_t &yValue) {
+    SetAxis(xAxis, xDirection, xValue);
+    SetAxis(yAxis, yDirection, yValue);
+}
+
+void PlatformFighter::SetLeftStick(const uint16_t &xValue, const uint16_t &yValue) {
+    SetStick(&_outputs->leftStickX, &_outputs->leftStickY, directions.x, directions.y, xValue, yValue);
+}
+
+void PlatformFighter::SetRightStick(const uint16_t &xValue, const uint16_t &yValue) {
+    SetStick(&_outputs->rightStickX, &_outputs->leftStickY, directions.x, directions.y, xValue, yValue);
+}
+
+void PlatformFighter::SetAngledFSmash(const uint16_t &xValue, const uint16_t yValue) {
+    SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, xValue, yValue);
 }

--- a/src/modes/PlatformFighter.cpp
+++ b/src/modes/PlatformFighter.cpp
@@ -13,13 +13,26 @@ PlatformFighter::PlatformFighter(socd::SocdType socd_type, uint8_t analog_stick_
     _horizontal_socd = false;
 }
 
-void PlatformFighter::SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value) {
-    *axis = ANALOG_STICK_NEUTRAL + direction * (uint8_t)(value / (10000 / _analog_stick_length));
-}
-
 void PlatformFighter::HandleSocd() {
     _horizontal_socd = _inputs->left && _inputs->right;
     InputMode::HandleSocd();
+}
+
+void PlatformFighter::UpdateDirections() {
+    ControllerMode::UpdateDirections(
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->up,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
+    );
+}
+
+void PlatformFighter::SetAxis(uint8_t* axis, const int8_t &direction, const uint16_t &value) {
+    *axis = ANALOG_STICK_NEUTRAL + direction * (uint8_t)(value / (10000 / _analog_stick_length));
 }
 
 void PlatformFighter::SetLeftStickX(const uint16_t &value) {

--- a/src/modes/PlatformFighter.cpp
+++ b/src/modes/PlatformFighter.cpp
@@ -1,0 +1,19 @@
+#include "modes/PlatformFighter.hpp"
+
+PlatformFighter::PlatformFighter(socd::SocdType socd_type, uint8_t analog_stick_length)
+    : ControllerMode(socd_type, analog_stick_length) {
+    _socd_pair_count = 4;
+    _socd_pairs = new socd::SocdPair[_socd_pair_count]{
+        socd::SocdPair{ &InputState::left,    &InputState::right },
+        socd::SocdPair{ &InputState::down,   &InputState::up     },
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+    };
+
+    _horizontal_socd = false;
+}
+
+void PlatformFighter::HandleSocd() {
+    _horizontal_socd = _inputs->left && _inputs->right;
+    InputMode::HandleSocd();
+}

--- a/src/modes/PlatformFighter.cpp
+++ b/src/modes/PlatformFighter.cpp
@@ -52,7 +52,7 @@ void PlatformFighter::SetLeftStick(const uint16_t &xValue, const uint16_t &yValu
     SetStick(&_outputs->leftStickX, &_outputs->leftStickY, directions.x, directions.y, xValue, yValue);
 }
 
-void PlatformFighter::SetRightStick(const uint16_t &xValue, const uint16_t &yValue) {
+void PlatformFighter::SetCStick(const uint16_t &xValue, const uint16_t &yValue) {
     SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.x, directions.y, xValue, yValue);
 }
 

--- a/src/modes/PlatformFighter.cpp
+++ b/src/modes/PlatformFighter.cpp
@@ -53,7 +53,7 @@ void PlatformFighter::SetLeftStick(const uint16_t &xValue, const uint16_t &yValu
 }
 
 void PlatformFighter::SetRightStick(const uint16_t &xValue, const uint16_t &yValue) {
-    SetStick(&_outputs->rightStickX, &_outputs->leftStickY, directions.x, directions.y, xValue, yValue);
+    SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.x, directions.y, xValue, yValue);
 }
 
 void PlatformFighter::SetAngledFSmash(const uint16_t &xValue, const uint16_t yValue) {

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -45,16 +45,7 @@ void ProjectM::UpdateDigitalOutputs() {
 }
 
 void ProjectM::UpdateAnalogOutputs() {
-    UpdateDirections(
-        _inputs->left,
-        _inputs->right,
-        _inputs->down,
-        _inputs->up,
-        _inputs->c_left,
-        _inputs->c_right,
-        _inputs->c_down,
-        _inputs->c_up
-    );
+    UpdateDirections();
 
     bool shield_button_pressed = _inputs->l || _inputs->lightshield || _inputs->midshield;
 

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -1,9 +1,7 @@
 #include "modes/ProjectM.hpp"
 
-#define ANALOG_STICK_LENGTH 100
-
 ProjectM::ProjectM(socd::SocdType socd_type, bool ledgedash_max_jump_traj, bool true_z_press)
-    : ControllerMode(socd_type) {
+    : ControllerMode(socd_type, 100) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
         socd::SocdPair{&InputState::left,    &InputState::right  },
@@ -70,9 +68,6 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -1,7 +1,6 @@
 #include "modes/ProjectM.hpp"
 
 #define ANALOG_STICK_MIN 28
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 228
 
 ProjectM::ProjectM(socd::SocdType socd_type, bool ledgedash_max_jump_traj, bool true_z_press)

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -74,57 +74,49 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     bool shield_button_pressed = inputs.l || inputs.lightshield || inputs.midshield;
 
     if (directions.diagonal) {
-        if (directions.y == 1) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 83);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 93);
+        if (directions.y > 0) {
+            SetLeftStick(outputs, 8300, 9300); // 48.25195°
         }
     }
 
     if (inputs.mod_x) {
         if (directions.horizontal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
+            SetLeftStickX(outputs, 7000);
         }
         if (directions.vertical) {
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 60);
+            SetLeftStickY(outputs, 6000);
         }
 
+        // Angled fsmash
         if (directions.cx != 0) {
-            outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 65);
-            outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.y * 23);
+            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
         }
 
         if (directions.diagonal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 34);
+            SetLeftStick(outputs, 7000, 3400); // 25.90651°
 
             if (inputs.b) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 85);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 31);
+                SetLeftStick(outputs, 8500, 3100); // 20.03721°
             }
 
             if (inputs.r) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 82);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
+                SetLeftStick(outputs, 8200, 3500); // 23.11421°
             }
 
             if (inputs.c_up) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 77);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 55);
+                SetLeftStick(outputs, 7700, 5500); // 35.53768°
             }
 
             if (inputs.c_down) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 82);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 36);
+                SetLeftStick(outputs, 8200, 3600); // 23.70265°
             }
 
             if (inputs.c_left) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 84);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 50);
+                SetLeftStick(outputs, 8400, 5000); // 30.76272°
             }
 
             if (inputs.c_right) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 72);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 61);
+                SetLeftStick(outputs, 7200, 6100); // 40.27201°
             }
         }
     }
@@ -138,37 +130,30 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         }
 
         if (directions.diagonal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 28);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 58);
+            SetLeftStick(outputs, 2800, 5800); // 64.23067°
 
             if (inputs.b) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 28);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 85);
+                SetLeftStick(outputs, 2800, 8500); // 71.76751°
             }
 
             if (inputs.r) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 82);
+                SetLeftStick(outputs, 5100, 8200); // 58.1204°
             }
 
             if (inputs.c_up) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 55);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 77);
+                SetLeftStick(outputs, 5500, 7700); // 54.46232°
             }
 
             if (inputs.c_down) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 34);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 82);
+                SetLeftStick(outputs, 3400, 8200); // 67.47943°
             }
 
             if (inputs.c_left) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 40);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 84);
+                SetLeftStick(outputs, 4000, 8400); // 64.53665°
             }
 
             if (inputs.c_right) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 62);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 72);
+                SetLeftStick(outputs, 6200, 7200); // 49.26789°
             }
         }
     }
@@ -177,17 +162,15 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // angled fsmash).
     // We don't apply this for c-up + c-left/c-right in case we want to implement
     // C-stick nair somehow.
-    if (directions.cx != 0 && directions.cy == -1) {
-        // 3000 9875 = 30 78
-        outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 35);
-        outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.cy * 98);
+    if (directions.cx != 0 && directions.cy < 0) {
+        SetLeftStick(outputs, 3500, 9800); // 70.34618°
     }
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
     if (ledgedash_max_jump_traj && horizontal_socd && !directions.vertical &&
         !shield_button_pressed) {
-        outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 100);
+        SetLeftStickX(outputs, 10000);
     }
 
     if (inputs.lightshield) {
@@ -212,8 +195,7 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
-        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
+        SetRightStick(outputs, 0000, 0000);
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -1,23 +1,9 @@
 #include "modes/ProjectM.hpp"
 
 ProjectM::ProjectM(socd::SocdType socd_type, bool ledgedash_max_jump_traj, bool true_z_press)
-    : ControllerMode(socd_type, 100) {
-    _socd_pair_count = 4;
-    _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
-    };
-
+    : PlatformFighter(socd_type) {
     this->ledgedash_max_jump_traj = ledgedash_max_jump_traj;
     this->true_z_press = true_z_press;
-    horizontal_socd = false;
-}
-
-void ProjectM::HandleSocd() {
-    horizontal_socd = _inputs->left && _inputs->right;
-    InputMode::HandleSocd();
 }
 
 void ProjectM::UpdateDigitalOutputs() {
@@ -167,7 +153,7 @@ void ProjectM::UpdateAnalogOutputs() {
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
-    if (ledgedash_max_jump_traj && horizontal_socd && !directions.vertical &&
+    if (ledgedash_max_jump_traj && _horizontal_socd && !directions.vertical &&
         !shield_button_pressed) {
         SetLeftStickX(10000);
     }

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -81,100 +81,100 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
 
     if (directions.diagonal) {
         if (directions.y == 1) {
-            outputs.leftStickX = 128 + (directions.x * 83);
-            outputs.leftStickY = 128 + (directions.y * 93);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 83);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 93);
         }
     }
 
     if (inputs.mod_x) {
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 70);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
         }
         if (directions.vertical) {
-            outputs.leftStickY = 128 + (directions.y * 60);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 60);
         }
 
         if (directions.cx != 0) {
-            outputs.rightStickX = 128 + (directions.cx * 65);
-            outputs.rightStickY = 128 + (directions.y * 23);
+            outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 65);
+            outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.y * 23);
         }
 
         if (directions.diagonal) {
-            outputs.leftStickX = 128 + (directions.x * 70);
-            outputs.leftStickY = 128 + (directions.y * 34);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 34);
 
             if (inputs.b) {
-                outputs.leftStickX = 128 + (directions.x * 85);
-                outputs.leftStickY = 128 + (directions.y * 31);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 85);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 31);
             }
 
             if (inputs.r) {
-                outputs.leftStickX = 128 + (directions.x * 82);
-                outputs.leftStickY = 128 + (directions.y * 35);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 82);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
             }
 
             if (inputs.c_up) {
-                outputs.leftStickX = 128 + (directions.x * 77);
-                outputs.leftStickY = 128 + (directions.y * 55);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 77);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 55);
             }
 
             if (inputs.c_down) {
-                outputs.leftStickX = 128 + (directions.x * 82);
-                outputs.leftStickY = 128 + (directions.y * 36);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 82);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 36);
             }
 
             if (inputs.c_left) {
-                outputs.leftStickX = 128 + (directions.x * 84);
-                outputs.leftStickY = 128 + (directions.y * 50);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 84);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 50);
             }
 
             if (inputs.c_right) {
-                outputs.leftStickX = 128 + (directions.x * 72);
-                outputs.leftStickY = 128 + (directions.y * 61);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 72);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 61);
             }
         }
     }
 
     if (inputs.mod_y) {
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 35);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
         }
         if (directions.vertical) {
-            outputs.leftStickY = 128 + (directions.y * 70);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
         }
 
         if (directions.diagonal) {
-            outputs.leftStickX = 128 + (directions.x * 28);
-            outputs.leftStickY = 128 + (directions.y * 58);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 28);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 58);
 
             if (inputs.b) {
-                outputs.leftStickX = 128 + (directions.x * 28);
-                outputs.leftStickY = 128 + (directions.y * 85);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 28);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 85);
             }
 
             if (inputs.r) {
-                outputs.leftStickX = 128 + (directions.x * 51);
-                outputs.leftStickY = 128 + (directions.y * 82);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 82);
             }
 
             if (inputs.c_up) {
-                outputs.leftStickX = 128 + (directions.x * 55);
-                outputs.leftStickY = 128 + (directions.y * 77);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 55);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 77);
             }
 
             if (inputs.c_down) {
-                outputs.leftStickX = 128 + (directions.x * 34);
-                outputs.leftStickY = 128 + (directions.y * 82);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 34);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 82);
             }
 
             if (inputs.c_left) {
-                outputs.leftStickX = 128 + (directions.x * 40);
-                outputs.leftStickY = 128 + (directions.y * 84);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 40);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 84);
             }
 
             if (inputs.c_right) {
-                outputs.leftStickX = 128 + (directions.x * 62);
-                outputs.leftStickY = 128 + (directions.y * 72);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 62);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 72);
             }
         }
     }
@@ -185,15 +185,15 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // C-stick nair somehow.
     if (directions.cx != 0 && directions.cy == -1) {
         // 3000 9875 = 30 78
-        outputs.rightStickX = 128 + (directions.cx * 35);
-        outputs.rightStickY = 128 + (directions.cy * 98);
+        outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 35);
+        outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.cy * 98);
     }
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
     if (ledgedash_max_jump_traj && horizontal_socd && !directions.vertical &&
         !shield_button_pressed) {
-        outputs.leftStickX = 128 + (directions.x * 100);
+        outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 100);
     }
 
     if (inputs.lightshield) {
@@ -218,8 +218,8 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = 128;
-        outputs.rightStickY = 128;
+        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
+        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -20,45 +20,45 @@ void ProjectM::HandleSocd(InputState &inputs) {
     InputMode::HandleSocd(inputs);
 }
 
-void ProjectM::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.a = inputs.a;
-    outputs.b = inputs.b;
-    outputs.x = inputs.x;
-    outputs.y = inputs.y;
+void ProjectM::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->a = inputs.a;
+    outputs->b = inputs.b;
+    outputs->x = inputs.x;
+    outputs->y = inputs.y;
     // True Z press vs macro lightshield + A.
     if (true_z_press || inputs.mod_x) {
-        outputs.buttonR = inputs.z;
+        outputs->buttonR = inputs.z;
     } else {
-        outputs.a = inputs.a || inputs.z;
+        outputs->a = inputs.a || inputs.z;
     }
     if (inputs.nunchuk_connected) {
-        outputs.triggerLDigital = inputs.nunchuk_z;
+        outputs->triggerLDigital = inputs.nunchuk_z;
     } else {
-        outputs.triggerLDigital = inputs.l;
+        outputs->triggerLDigital = inputs.l;
     }
-    outputs.triggerRDigital = inputs.r;
-    outputs.start = inputs.start;
+    outputs->triggerRDigital = inputs.r;
+    outputs->start = inputs.start;
 
     // D-Pad layer can be activated by holding Mod X + Mod Y, or by holding the C
     // button on a nunchuk.
     if ((inputs.mod_x && inputs.mod_y) || inputs.nunchuk_c) {
-        outputs.dpadUp = inputs.c_up;
-        outputs.dpadDown = inputs.c_down;
-        outputs.dpadLeft = inputs.c_left;
-        outputs.dpadRight = inputs.c_right;
+        outputs->dpadUp = inputs.c_up;
+        outputs->dpadDown = inputs.c_down;
+        outputs->dpadLeft = inputs.c_left;
+        outputs->dpadRight = inputs.c_right;
     }
 
     // Don't override dpad up if it's already pressed using the MX + MY dpad
     // layer.
-    outputs.dpadUp = outputs.dpadUp || inputs.midshield;
+    outputs->dpadUp = outputs->dpadUp || inputs.midshield;
 
     if (inputs.select)
-        outputs.dpadLeft = true;
+        outputs->dpadLeft = true;
     if (inputs.home)
-        outputs.dpadRight = true;
+        outputs->dpadRight = true;
 }
 
-void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void ProjectM::UpdateAnalogOutputs(InputState &inputs) {
     UpdateDirections(
         inputs.left,
         inputs.right,
@@ -67,93 +67,92 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 
     bool shield_button_pressed = inputs.l || inputs.lightshield || inputs.midshield;
 
     if (directions.diagonal) {
         if (directions.y > 0) {
-            SetLeftStick(outputs, 8300, 9300); // 48.25195°
+            SetLeftStick(8300, 9300); // 48.25195°
         }
     }
 
     if (inputs.mod_x) {
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 7000);
+            SetLeftStickX(7000);
         }
         if (directions.vertical) {
-            SetLeftStickY(outputs, 6000);
+            SetLeftStickY(6000);
         }
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
+            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
         }
 
         if (directions.diagonal) {
-            SetLeftStick(outputs, 7000, 3400); // 25.90651°
+            SetLeftStick(7000, 3400); // 25.90651°
 
             if (inputs.b) {
-                SetLeftStick(outputs, 8500, 3100); // 20.03721°
+                SetLeftStick(8500, 3100); // 20.03721°
             }
 
             if (inputs.r) {
-                SetLeftStick(outputs, 8200, 3500); // 23.11421°
+                SetLeftStick(8200, 3500); // 23.11421°
             }
 
             if (inputs.c_up) {
-                SetLeftStick(outputs, 7700, 5500); // 35.53768°
+                SetLeftStick(7700, 5500); // 35.53768°
             }
 
             if (inputs.c_down) {
-                SetLeftStick(outputs, 8200, 3600); // 23.70265°
+                SetLeftStick(8200, 3600); // 23.70265°
             }
 
             if (inputs.c_left) {
-                SetLeftStick(outputs, 8400, 5000); // 30.76272°
+                SetLeftStick(8400, 5000); // 30.76272°
             }
 
             if (inputs.c_right) {
-                SetLeftStick(outputs, 7200, 6100); // 40.27201°
+                SetLeftStick(7200, 6100); // 40.27201°
             }
         }
     }
 
     if (inputs.mod_y) {
         if (directions.horizontal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
+            outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
         }
         if (directions.vertical) {
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
+            outputs->leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
         }
 
         if (directions.diagonal) {
-            SetLeftStick(outputs, 2800, 5800); // 64.23067°
+            SetLeftStick(2800, 5800); // 64.23067°
 
             if (inputs.b) {
-                SetLeftStick(outputs, 2800, 8500); // 71.76751°
+                SetLeftStick(2800, 8500); // 71.76751°
             }
 
             if (inputs.r) {
-                SetLeftStick(outputs, 5100, 8200); // 58.1204°
+                SetLeftStick(5100, 8200); // 58.1204°
             }
 
             if (inputs.c_up) {
-                SetLeftStick(outputs, 5500, 7700); // 54.46232°
+                SetLeftStick(5500, 7700); // 54.46232°
             }
 
             if (inputs.c_down) {
-                SetLeftStick(outputs, 3400, 8200); // 67.47943°
+                SetLeftStick(3400, 8200); // 67.47943°
             }
 
             if (inputs.c_left) {
-                SetLeftStick(outputs, 4000, 8400); // 64.53665°
+                SetLeftStick(4000, 8400); // 64.53665°
             }
 
             if (inputs.c_right) {
-                SetLeftStick(outputs, 6200, 7200); // 49.26789°
+                SetLeftStick(6200, 7200); // 49.26789°
             }
         }
     }
@@ -163,44 +162,44 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // We don't apply this for c-up + c-left/c-right in case we want to implement
     // C-stick nair somehow.
     if (directions.cx != 0 && directions.cy < 0) {
-        SetLeftStick(outputs, 3500, 9800); // 70.34618°
+        SetLeftStick(3500, 9800); // 70.34618°
     }
 
     // Horizontal SOCD overrides X-axis modifiers (for ledgedash maximum jump
     // trajectory).
     if (ledgedash_max_jump_traj && horizontal_socd && !directions.vertical &&
         !shield_button_pressed) {
-        SetLeftStickX(outputs, 10000);
+        SetLeftStickX(10000);
     }
 
     if (inputs.lightshield) {
-        outputs.triggerRAnalog = 49;
+        outputs->triggerRAnalog = 49;
     }
     if (inputs.midshield) {
-        outputs.triggerRAnalog = 94;
+        outputs->triggerRAnalog = 94;
     }
 
     // Send lightshield input if we are using Z = lightshield + A macro.
     if (inputs.z && !(inputs.mod_x || true_z_press)) {
-        outputs.triggerRAnalog = 49;
+        outputs->triggerRAnalog = 49;
     }
 
-    if (outputs.triggerLDigital) {
-        outputs.triggerLAnalog = 140;
+    if (outputs->triggerLDigital) {
+        outputs->triggerLAnalog = 140;
     }
 
-    if (outputs.triggerRDigital) {
-        outputs.triggerRAnalog = 140;
+    if (outputs->triggerRDigital) {
+        outputs->triggerRAnalog = 140;
     }
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        SetRightStick(outputs, 0000, 0000);
+        SetRightStick(0000, 0000);
     }
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs.leftStickX = inputs.nunchuk_x;
-        outputs.leftStickY = inputs.nunchuk_y;
+        outputs->leftStickX = inputs.nunchuk_x;
+        outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -122,10 +122,10 @@ void ProjectM::UpdateAnalogOutputs() {
 
     if (_inputs->mod_y) {
         if (directions.horizontal) {
-            _outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
+            SetLeftStickX(3500);
         }
         if (directions.vertical) {
-            _outputs->leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
+            SetLeftStickY(7000);
         }
 
         if (directions.diagonal) {

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -88,7 +88,7 @@ void ProjectM::UpdateAnalogOutputs() {
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
+            SetAngledFSmash(6500, 2300); // 19.48613°
         }
 
         if (directions.diagonal) {

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -171,7 +171,7 @@ void ProjectM::UpdateAnalogOutputs() {
 
     // Shut off c-stick when using dpad layer.
     if (_inputs->mod_x && _inputs->mod_y) {
-        SetRightStick(0000, 0000);
+        SetCStick(0000, 0000);
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -1,7 +1,6 @@
 #include "modes/ProjectM.hpp"
 
-#define ANALOG_STICK_MIN 28
-#define ANALOG_STICK_MAX 228
+#define ANALOG_STICK_LENGTH 100
 
 ProjectM::ProjectM(socd::SocdType socd_type, bool ledgedash_max_jump_traj, bool true_z_press)
     : ControllerMode(socd_type) {

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -15,62 +15,62 @@ ProjectM::ProjectM(socd::SocdType socd_type, bool ledgedash_max_jump_traj, bool 
     horizontal_socd = false;
 }
 
-void ProjectM::HandleSocd(InputState &inputs) {
-    horizontal_socd = inputs.left && inputs.right;
-    InputMode::HandleSocd(inputs);
+void ProjectM::HandleSocd() {
+    horizontal_socd = _inputs->left && _inputs->right;
+    InputMode::HandleSocd();
 }
 
-void ProjectM::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->a = inputs.a;
-    outputs->b = inputs.b;
-    outputs->x = inputs.x;
-    outputs->y = inputs.y;
+void ProjectM::UpdateDigitalOutputs() {
+    _outputs->a = _inputs->a;
+    _outputs->b = _inputs->b;
+    _outputs->x = _inputs->x;
+    _outputs->y = _inputs->y;
     // True Z press vs macro lightshield + A.
-    if (true_z_press || inputs.mod_x) {
-        outputs->buttonR = inputs.z;
+    if (true_z_press || _inputs->mod_x) {
+        _outputs->buttonR = _inputs->z;
     } else {
-        outputs->a = inputs.a || inputs.z;
+        _outputs->a = _inputs->a || _inputs->z;
     }
-    if (inputs.nunchuk_connected) {
-        outputs->triggerLDigital = inputs.nunchuk_z;
+    if (_inputs->nunchuk_connected) {
+        _outputs->triggerLDigital = _inputs->nunchuk_z;
     } else {
-        outputs->triggerLDigital = inputs.l;
+        _outputs->triggerLDigital = _inputs->l;
     }
-    outputs->triggerRDigital = inputs.r;
-    outputs->start = inputs.start;
+    _outputs->triggerRDigital = _inputs->r;
+    _outputs->start = _inputs->start;
 
     // D-Pad layer can be activated by holding Mod X + Mod Y, or by holding the C
     // button on a nunchuk.
-    if ((inputs.mod_x && inputs.mod_y) || inputs.nunchuk_c) {
-        outputs->dpadUp = inputs.c_up;
-        outputs->dpadDown = inputs.c_down;
-        outputs->dpadLeft = inputs.c_left;
-        outputs->dpadRight = inputs.c_right;
+    if ((_inputs->mod_x && _inputs->mod_y) || _inputs->nunchuk_c) {
+        _outputs->dpadUp = _inputs->c_up;
+        _outputs->dpadDown = _inputs->c_down;
+        _outputs->dpadLeft = _inputs->c_left;
+        _outputs->dpadRight = _inputs->c_right;
     }
 
     // Don't override dpad up if it's already pressed using the MX + MY dpad
     // layer.
-    outputs->dpadUp = outputs->dpadUp || inputs.midshield;
+    _outputs->dpadUp = _outputs->dpadUp || _inputs->midshield;
 
-    if (inputs.select)
-        outputs->dpadLeft = true;
-    if (inputs.home)
-        outputs->dpadRight = true;
+    if (_inputs->select)
+        _outputs->dpadLeft = true;
+    if (_inputs->home)
+        _outputs->dpadRight = true;
 }
 
-void ProjectM::UpdateAnalogOutputs(InputState &inputs) {
+void ProjectM::UpdateAnalogOutputs() {
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.up,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->up,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 
-    bool shield_button_pressed = inputs.l || inputs.lightshield || inputs.midshield;
+    bool shield_button_pressed = _inputs->l || _inputs->lightshield || _inputs->midshield;
 
     if (directions.diagonal) {
         if (directions.y > 0) {
@@ -78,7 +78,7 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs) {
         }
     }
 
-    if (inputs.mod_x) {
+    if (_inputs->mod_x) {
         if (directions.horizontal) {
             SetLeftStickX(7000);
         }
@@ -88,70 +88,70 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs) {
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
+            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
         }
 
         if (directions.diagonal) {
             SetLeftStick(7000, 3400); // 25.90651°
 
-            if (inputs.b) {
+            if (_inputs->b) {
                 SetLeftStick(8500, 3100); // 20.03721°
             }
 
-            if (inputs.r) {
+            if (_inputs->r) {
                 SetLeftStick(8200, 3500); // 23.11421°
             }
 
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(7700, 5500); // 35.53768°
             }
 
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(8200, 3600); // 23.70265°
             }
 
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(8400, 5000); // 30.76272°
             }
 
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(7200, 6100); // 40.27201°
             }
         }
     }
 
-    if (inputs.mod_y) {
+    if (_inputs->mod_y) {
         if (directions.horizontal) {
-            outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
+            _outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
         }
         if (directions.vertical) {
-            outputs->leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
+            _outputs->leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
         }
 
         if (directions.diagonal) {
             SetLeftStick(2800, 5800); // 64.23067°
 
-            if (inputs.b) {
+            if (_inputs->b) {
                 SetLeftStick(2800, 8500); // 71.76751°
             }
 
-            if (inputs.r) {
+            if (_inputs->r) {
                 SetLeftStick(5100, 8200); // 58.1204°
             }
 
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(5500, 7700); // 54.46232°
             }
 
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(3400, 8200); // 67.47943°
             }
 
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(4000, 8400); // 64.53665°
             }
 
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(6200, 7200); // 49.26789°
             }
         }
@@ -172,34 +172,34 @@ void ProjectM::UpdateAnalogOutputs(InputState &inputs) {
         SetLeftStickX(10000);
     }
 
-    if (inputs.lightshield) {
-        outputs->triggerRAnalog = 49;
+    if (_inputs->lightshield) {
+        _outputs->triggerRAnalog = 49;
     }
-    if (inputs.midshield) {
-        outputs->triggerRAnalog = 94;
+    if (_inputs->midshield) {
+        _outputs->triggerRAnalog = 94;
     }
 
     // Send lightshield input if we are using Z = lightshield + A macro.
-    if (inputs.z && !(inputs.mod_x || true_z_press)) {
-        outputs->triggerRAnalog = 49;
+    if (_inputs->z && !(_inputs->mod_x || true_z_press)) {
+        _outputs->triggerRAnalog = 49;
     }
 
-    if (outputs->triggerLDigital) {
-        outputs->triggerLAnalog = 140;
+    if (_outputs->triggerLDigital) {
+        _outputs->triggerLAnalog = 140;
     }
 
-    if (outputs->triggerRDigital) {
-        outputs->triggerRAnalog = 140;
+    if (_outputs->triggerRDigital) {
+        _outputs->triggerRAnalog = 140;
     }
 
     // Shut off c-stick when using dpad layer.
-    if (inputs.mod_x && inputs.mod_y) {
+    if (_inputs->mod_x && _inputs->mod_y) {
         SetRightStick(0000, 0000);
     }
 
     // Nunchuk overrides left stick.
-    if (inputs.nunchuk_connected) {
-        outputs->leftStickX = inputs.nunchuk_x;
-        outputs->leftStickY = inputs.nunchuk_y;
+    if (_inputs->nunchuk_connected) {
+        _outputs->leftStickX = _inputs->nunchuk_x;
+        _outputs->leftStickY = _inputs->nunchuk_y;
     }
 }

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -64,83 +64,83 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &output
 
     if (inputs.mod_x) {
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 66);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 66);
         }
 
         // Angled fsmash
         if (directions.cx != 0) {
-            outputs.rightStickX = 128 + (directions.cx * 65);
-            outputs.rightStickY = 128 + (directions.y * 23);
+            outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 65);
+            outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.y * 23);
         }
 
         // Need to check coord system in RoA
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            outputs.leftStickX = 128 + (directions.x * 59);
-            outputs.leftStickY = 128 + (directions.y * 23);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 59);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 23);
 
             if (inputs.c_down) {
-                outputs.leftStickX = 128 + (directions.x * 49);
-                outputs.leftStickY = 128 + (directions.y * 24);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 49);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 24);
             }
 
             if (inputs.c_left) {
-                outputs.leftStickX = 128 + (directions.x * 52);
-                outputs.leftStickY = 128 + (directions.y * 31);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 52);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 31);
             }
 
             if (inputs.c_up) {
-                outputs.leftStickX = 128 + (directions.x * 49);
-                outputs.leftStickY = 128 + (directions.y * 35);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 49);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
             }
 
             if (inputs.c_right) {
-                outputs.leftStickX = 128 + (directions.x * 51);
-                outputs.leftStickY = 128 + (directions.y * 43);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 43);
             }
         }
     }
 
     if (inputs.mod_y) {
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 44);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            outputs.leftStickX = 128 + (directions.x * 44);
-            outputs.leftStickY = 128 + (directions.y * 113);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 113);
 
             if (inputs.c_down) {
-                outputs.leftStickX = 128 + (directions.x * 44);
-                outputs.leftStickY = 128 + (directions.y * 90);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 90);
             }
 
             if (inputs.c_left) {
-                outputs.leftStickX = 128 + (directions.x * 44);
-                outputs.leftStickY = 128 + (directions.y * 74);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 74);
             }
 
             if (inputs.c_up) {
-                outputs.leftStickX = 128 + (directions.x * 45);
-                outputs.leftStickY = 128 + (directions.y * 63);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 45);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 63);
             }
 
             if (inputs.c_right) {
-                outputs.leftStickX = 128 + (directions.x * 47);
-                outputs.leftStickY = 128 + (directions.y * 57);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 47);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 57);
             }
         }
     }
 
     if (inputs.l) {
         if (directions.horizontal)
-            outputs.leftStickX = 128 + (directions.x * 100);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 100);
         if (directions.vertical)
-            outputs.leftStickY = 128 + (directions.y * 100);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 100);
         if (directions.horizontal && (directions.y == -1)) {
-            outputs.leftStickX = 128 + (directions.x * 100);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 100);
             outputs.leftStickY = ANALOG_STICK_MIN;
         }
     }
@@ -148,16 +148,16 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &output
     if (inputs.r) {
         if (directions.diagonal) {
             if (inputs.mod_y) {
-                outputs.leftStickX = 128 + (directions.x * 40);
-                outputs.leftStickY = 128 + (directions.y * 68);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 40);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 68);
             }
         }
     }
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = 128;
-        outputs.rightStickY = 128;
+        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
+        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -1,7 +1,6 @@
 #include "modes/RivalsOfAether.hpp"
 
 #define ANALOG_STICK_MIN 28
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 228
 
 RivalsOfAether::RivalsOfAether(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -1,8 +1,6 @@
 #include "modes/RivalsOfAether.hpp"
 
-#define ANALOG_STICK_LENGTH 100
-
-RivalsOfAether::RivalsOfAether(socd::SocdType socd_type) : ControllerMode(socd_type) {
+RivalsOfAether::RivalsOfAether(socd::SocdType socd_type) : ControllerMode(socd_type, 100) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
         socd::SocdPair{&InputState::left,    &InputState::right  },
@@ -53,9 +51,6 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &output
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 
@@ -140,7 +135,7 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &output
             outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 100);
         if (directions.horizontal && (directions.y == -1)) {
             outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 100);
-            outputs.leftStickY = ANALOG_STICK_MIN;
+            outputs.leftStickY = 28; // TODO
         }
     }
 

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -62,7 +62,7 @@ void RivalsOfAether::UpdateAnalogOutputs() {
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
+            SetAngledFSmash(6500, 2300); // 19.48613°
         }
 
         // Need to check coord system in RoA

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -1,14 +1,7 @@
 #include "modes/RivalsOfAether.hpp"
 
-RivalsOfAether::RivalsOfAether(socd::SocdType socd_type) : ControllerMode(socd_type, 100) {
-    _socd_pair_count = 4;
-    _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
-    };
-}
+RivalsOfAether::RivalsOfAether(socd::SocdType socd_type)
+    : PlatformFighter(socd_type) { }
 
 void RivalsOfAether::UpdateDigitalOutputs() {
     _outputs->a = _inputs->a;

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -10,37 +10,37 @@ RivalsOfAether::RivalsOfAether(socd::SocdType socd_type) : ControllerMode(socd_t
     };
 }
 
-void RivalsOfAether::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.a = inputs.a;
-    outputs.b = inputs.b;
-    outputs.x = inputs.x;
-    outputs.y = inputs.y;
-    outputs.buttonR = inputs.z;
+void RivalsOfAether::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->a = inputs.a;
+    outputs->b = inputs.b;
+    outputs->x = inputs.x;
+    outputs->y = inputs.y;
+    outputs->buttonR = inputs.z;
     if (inputs.nunchuk_connected) {
         // Lightshield with C button.
         if (inputs.nunchuk_c) {
-            outputs.triggerLAnalog = 49;
+            outputs->triggerLAnalog = 49;
         }
-        outputs.triggerLDigital = inputs.nunchuk_z;
+        outputs->triggerLDigital = inputs.nunchuk_z;
     } else {
-        outputs.triggerLDigital = inputs.l;
+        outputs->triggerLDigital = inputs.l;
     }
-    outputs.triggerRDigital = inputs.r;
-    outputs.start = inputs.start;
+    outputs->triggerRDigital = inputs.r;
+    outputs->start = inputs.start;
 
     /********* DPAD *********/
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.dpadUp = inputs.c_up;
-        outputs.dpadDown = inputs.c_down;
-        outputs.dpadLeft = inputs.c_left;
-        outputs.dpadRight = inputs.c_right;
+        outputs->dpadUp = inputs.c_up;
+        outputs->dpadDown = inputs.c_down;
+        outputs->dpadLeft = inputs.c_left;
+        outputs->dpadRight = inputs.c_right;
     }
 
-    outputs.select = inputs.select;
-    outputs.home = inputs.home;
+    outputs->select = inputs.select;
+    outputs->home = inputs.home;
 }
 
-void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs) {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
         inputs.left,
@@ -50,99 +50,98 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &output
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 
     bool shield_button_pressed = inputs.l || inputs.r;
 
     if (inputs.mod_x) {
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 6600);
+            SetLeftStickX(6600);
         }
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
+            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
         }
 
         // Need to check coord system in RoA
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 5900, 2300); // 21.29735°
+            SetLeftStick(5900, 2300); // 21.29735°
 
             if (inputs.c_down) {
-                SetLeftStick(outputs, 4900, 2400); // 26.09542°
+                SetLeftStick(4900, 2400); // 26.09542°
             }
 
             if (inputs.c_left) {
-                SetLeftStick(outputs, 5200, 3100); // 30.80145°
+                SetLeftStick(5200, 3100); // 30.80145°
             }
 
             if (inputs.c_up) {
-                SetLeftStick(outputs, 4900, 3500); // 35.53768°
+                SetLeftStick(4900, 3500); // 35.53768°
             }
 
             if (inputs.c_right) {
-                SetLeftStick(outputs, 5100, 4300); // 40.13549°
+                SetLeftStick(5100, 4300); // 40.13549°
             }
         }
     }
 
     if (inputs.mod_y) {
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 4400);
+            SetLeftStickX(4400);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 4400, 11300); // 68.72503°
+            SetLeftStick(4400, 11300); // 68.72503°
 
             if (inputs.c_down) {
-                SetLeftStick(outputs, 4400, 9000); // 63.9465°
+                SetLeftStick(4400, 9000); // 63.9465°
             }
 
             if (inputs.c_left) {
-                SetLeftStick(outputs, 4400, 7400); // 59.26451°
+                SetLeftStick(4400, 7400); // 59.26451°
             }
 
             if (inputs.c_up) {
-                SetLeftStick(outputs, 4500, 6300); // 54.46232°
+                SetLeftStick(4500, 6300); // 54.46232°
             }
 
             if (inputs.c_right) {
-                SetLeftStick(outputs, 4700, 5700); // 50.49232°
+                SetLeftStick(4700, 5700); // 50.49232°
             }
         }
     }
 
     if (inputs.l) {
         if (directions.horizontal)
-            SetLeftStickX(outputs, 10000);
+            SetLeftStickX(10000);
         if (directions.vertical)
-            SetLeftStickY(outputs, 10000);
+            SetLeftStickY(10000);
         if (directions.horizontal && directions.y < 0) {
-            SetLeftStick(outputs, 10000, 2800); // 15.64225°
+            SetLeftStick(10000, 2800); // 15.64225°
         }
     }
 
     if (inputs.r) {
         if (directions.diagonal) {
             if (inputs.mod_y) {
-                SetLeftStick(outputs, 4000, 6800); // 59.53446°
+                SetLeftStick(4000, 6800); // 59.53446°
             }
         }
     }
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        SetLeftStick(outputs, 0000, 0000); // 0°
+        SetLeftStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs.leftStickX = inputs.nunchuk_x;
-        outputs.leftStickY = inputs.nunchuk_y;
+        outputs->leftStickX = inputs.nunchuk_x;
+        outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -1,7 +1,6 @@
 #include "modes/RivalsOfAether.hpp"
 
-#define ANALOG_STICK_MIN 28
-#define ANALOG_STICK_MAX 228
+#define ANALOG_STICK_LENGTH 100
 
 RivalsOfAether::RivalsOfAether(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -58,100 +58,86 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &output
 
     if (inputs.mod_x) {
         if (directions.horizontal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 66);
+            SetLeftStickX(outputs, 6600);
         }
 
         // Angled fsmash
         if (directions.cx != 0) {
-            outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 65);
-            outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.y * 23);
+            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
         }
 
         // Need to check coord system in RoA
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 59);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 23);
+            SetLeftStick(outputs, 5900, 2300); // 21.29735°
 
             if (inputs.c_down) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 49);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 24);
+                SetLeftStick(outputs, 4900, 2400); // 26.09542°
             }
 
             if (inputs.c_left) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 52);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 31);
+                SetLeftStick(outputs, 5200, 3100); // 30.80145°
             }
 
             if (inputs.c_up) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 49);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
+                SetLeftStick(outputs, 4900, 3500); // 35.53768°
             }
 
             if (inputs.c_right) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 43);
+                SetLeftStick(outputs, 5100, 4300); // 40.13549°
             }
         }
     }
 
     if (inputs.mod_y) {
         if (directions.horizontal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
+            SetLeftStickX(outputs, 4400);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 113);
+            SetLeftStick(outputs, 4400, 11300); // 68.72503°
 
             if (inputs.c_down) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 90);
+                SetLeftStick(outputs, 4400, 9000); // 63.9465°
             }
 
             if (inputs.c_left) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 74);
+                SetLeftStick(outputs, 4400, 7400); // 59.26451°
             }
 
             if (inputs.c_up) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 45);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 63);
+                SetLeftStick(outputs, 4500, 6300); // 54.46232°
             }
 
             if (inputs.c_right) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 47);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 57);
+                SetLeftStick(outputs, 4700, 5700); // 50.49232°
             }
         }
     }
 
     if (inputs.l) {
         if (directions.horizontal)
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 100);
+            SetLeftStickX(outputs, 10000);
         if (directions.vertical)
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 100);
-        if (directions.horizontal && (directions.y == -1)) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 100);
-            outputs.leftStickY = 28; // TODO
+            SetLeftStickY(outputs, 10000);
+        if (directions.horizontal && directions.y < 0) {
+            SetLeftStick(outputs, 10000, 2800); // 15.64225°
         }
     }
 
     if (inputs.r) {
         if (directions.diagonal) {
             if (inputs.mod_y) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 40);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 68);
+                SetLeftStick(outputs, 4000, 6800); // 59.53446°
             }
         }
     }
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
-        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
+        SetLeftStick(outputs, 0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -34,17 +34,7 @@ void RivalsOfAether::UpdateDigitalOutputs() {
 }
 
 void RivalsOfAether::UpdateAnalogOutputs() {
-    // Coordinate calculations to make modifier handling simpler.
-    UpdateDirections(
-        _inputs->left,
-        _inputs->right,
-        _inputs->down,
-        _inputs->up,
-        _inputs->c_left,
-        _inputs->c_right,
-        _inputs->c_down,
-        _inputs->c_up
-    );
+    UpdateDirections();
 
     bool shield_button_pressed = _inputs->l || _inputs->r;
 

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -10,59 +10,59 @@ RivalsOfAether::RivalsOfAether(socd::SocdType socd_type) : ControllerMode(socd_t
     };
 }
 
-void RivalsOfAether::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->a = inputs.a;
-    outputs->b = inputs.b;
-    outputs->x = inputs.x;
-    outputs->y = inputs.y;
-    outputs->buttonR = inputs.z;
-    if (inputs.nunchuk_connected) {
+void RivalsOfAether::UpdateDigitalOutputs() {
+    _outputs->a = _inputs->a;
+    _outputs->b = _inputs->b;
+    _outputs->x = _inputs->x;
+    _outputs->y = _inputs->y;
+    _outputs->buttonR = _inputs->z;
+    if (_inputs->nunchuk_connected) {
         // Lightshield with C button.
-        if (inputs.nunchuk_c) {
-            outputs->triggerLAnalog = 49;
+        if (_inputs->nunchuk_c) {
+            _outputs->triggerLAnalog = 49;
         }
-        outputs->triggerLDigital = inputs.nunchuk_z;
+        _outputs->triggerLDigital = _inputs->nunchuk_z;
     } else {
-        outputs->triggerLDigital = inputs.l;
+        _outputs->triggerLDigital = _inputs->l;
     }
-    outputs->triggerRDigital = inputs.r;
-    outputs->start = inputs.start;
+    _outputs->triggerRDigital = _inputs->r;
+    _outputs->start = _inputs->start;
 
     /********* DPAD *********/
-    if (inputs.mod_x && inputs.mod_y) {
-        outputs->dpadUp = inputs.c_up;
-        outputs->dpadDown = inputs.c_down;
-        outputs->dpadLeft = inputs.c_left;
-        outputs->dpadRight = inputs.c_right;
+    if (_inputs->mod_x && _inputs->mod_y) {
+        _outputs->dpadUp = _inputs->c_up;
+        _outputs->dpadDown = _inputs->c_down;
+        _outputs->dpadLeft = _inputs->c_left;
+        _outputs->dpadRight = _inputs->c_right;
     }
 
-    outputs->select = inputs.select;
-    outputs->home = inputs.home;
+    _outputs->select = _inputs->select;
+    _outputs->home = _inputs->home;
 }
 
-void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs) {
+void RivalsOfAether::UpdateAnalogOutputs() {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.up,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->up,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 
-    bool shield_button_pressed = inputs.l || inputs.r;
+    bool shield_button_pressed = _inputs->l || _inputs->r;
 
-    if (inputs.mod_x) {
+    if (_inputs->mod_x) {
         if (directions.horizontal) {
             SetLeftStickX(6600);
         }
 
         // Angled fsmash
         if (directions.cx != 0) {
-            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
+            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 6500, 2300); // 19.48613°
         }
 
         // Need to check coord system in RoA
@@ -71,25 +71,25 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs) {
         if (directions.diagonal && !shield_button_pressed) {
             SetLeftStick(5900, 2300); // 21.29735°
 
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(4900, 2400); // 26.09542°
             }
 
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(5200, 3100); // 30.80145°
             }
 
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(4900, 3500); // 35.53768°
             }
 
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(5100, 4300); // 40.13549°
             }
         }
     }
 
-    if (inputs.mod_y) {
+    if (_inputs->mod_y) {
         if (directions.horizontal) {
             SetLeftStickX(4400);
         }
@@ -98,25 +98,25 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs) {
         if (directions.diagonal && !shield_button_pressed) {
             SetLeftStick(4400, 11300); // 68.72503°
 
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(4400, 9000); // 63.9465°
             }
 
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(4400, 7400); // 59.26451°
             }
 
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(4500, 6300); // 54.46232°
             }
 
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(4700, 5700); // 50.49232°
             }
         }
     }
 
-    if (inputs.l) {
+    if (_inputs->l) {
         if (directions.horizontal)
             SetLeftStickX(10000);
         if (directions.vertical)
@@ -126,22 +126,22 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs) {
         }
     }
 
-    if (inputs.r) {
+    if (_inputs->r) {
         if (directions.diagonal) {
-            if (inputs.mod_y) {
+            if (_inputs->mod_y) {
                 SetLeftStick(4000, 6800); // 59.53446°
             }
         }
     }
 
     // Shut off c-stick when using dpad layer.
-    if (inputs.mod_x && inputs.mod_y) {
+    if (_inputs->mod_x && _inputs->mod_y) {
         SetLeftStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.
-    if (inputs.nunchuk_connected) {
-        outputs->leftStickX = inputs.nunchuk_x;
-        outputs->leftStickY = inputs.nunchuk_y;
+    if (_inputs->nunchuk_connected) {
+        _outputs->leftStickX = _inputs->nunchuk_x;
+        _outputs->leftStickY = _inputs->nunchuk_y;
     }
 }

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -29,17 +29,7 @@ void Ultimate::UpdateDigitalOutputs() {
 }
 
 void Ultimate::UpdateAnalogOutputs() {
-    // Coordinate calculations to make modifier handling simpler.
-    UpdateDirections(
-        _inputs->left,
-        _inputs->right,
-        _inputs->down,
-        _inputs->up,
-        _inputs->c_left,
-        _inputs->c_right,
-        _inputs->c_down,
-        _inputs->c_up
-    );
+    UpdateDirections();
 
     bool shield_button_pressed = _inputs->l || _inputs->r || _inputs->lightshield || _inputs->midshield;
 

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -52,194 +52,145 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
 
     if (inputs.mod_x) {
-        // MX + Horizontal = 6625 = 53
+        // MX + Horizontal
         if (directions.horizontal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-            // Horizontal Shield tilt = 51
+            SetLeftStickX(outputs, 5300);
+            // Horizontal Shield tilt
             if (shield_button_pressed) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
+                SetLeftStickX(outputs, 5100);
             }
-            // Horizontal Tilts = 36
+            // Horizontal Tilts
             if (inputs.a) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
+                SetLeftStickX(outputs, 3600);
             }
         }
-        // MX + Vertical = 44
+        // MX + Vertical
         if (directions.vertical) {
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
-            // Vertical Shield Tilt = 51
+            SetLeftStickY(outputs, 4400);
             if (shield_button_pressed) {
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 51);
+                SetLeftStickY(outputs, 5100);
             }
         }
         if (directions.diagonal) {
-            // MX + q1/2/3/4 = 53 35
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
+            // MX + q1/2/3/4
+            SetLeftStick(outputs, 5300, 3500); // 33.43987°
             if (shield_button_pressed) {
-                // MX + L, R, LS, and MS + q1/2/3/4 = 6375 3750 = 51 30
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 30);
+                // MX + L, R, LS, and MS + q1/2/3/4
+                SetLeftStick(outputs, 5100, 3000); // 30.46554°
             }
         }
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 127);
-            outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.y * 59);
+            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            // (33.44) = 53 35
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
-            // (39.05) = 53 43
+            SetLeftStick(outputs, 5300, 3500); // 33.43987°
             if (inputs.c_down) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 43);
+                SetLeftStick(outputs, 5300, 4300); // 39.05314°
             }
-            // (36.35) = 53 39
             if (inputs.c_left) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 39);
+                SetLeftStick(outputs, 5300, 3900); // 36.34746°
             }
-            // (30.32) = 56 41
             if (inputs.c_up) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 31);
+                SetLeftStick(outputs, 5300, 3100); // 30.32361°
             }
-            // (27.85) = 49 42
             if (inputs.c_right) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 28);
+                SetLeftStick(outputs, 5300, 2800); // 27.84758°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                // (33.29) = 67 44
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
-                // (39.38) = 67 55
+                SetLeftStick(outputs, 6700, 4400); // 33.29356°
                 if (inputs.c_down) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 55);
+                    SetLeftStick(outputs, 6700, 5500); // 39.38242°
                 }
-                // (36.18) = 67 49
                 if (inputs.c_left) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 49);
+                    SetLeftStick(outputs, 6700, 4900); // 36.17962°
                 }
-                // (30.2) = 67 39
                 if (inputs.c_up) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 39);
+                    SetLeftStick(outputs, 6700, 3900); // 30.20324°
                 }
-                // (27.58) = 67 35
                 if (inputs.c_right) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
+                    SetLeftStick(outputs, 6700, 3500); // 27.58203°
                 }
             }
 
             // Angled Ftilts
             if (inputs.a) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 26);
+                SetLeftStick(outputs, 3600, 2600); // 35.83765°
             }
         }
     }
 
     if (inputs.mod_y) {
-        // MY + Horizontal (even if shield is held) = 41
+        // MY + Horizontal (even if shield is held)
         if (directions.horizontal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 41);
+            SetLeftStickX(outputs, 4100);
             // MY Horizontal Tilts
             if (inputs.a) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
+                SetLeftStickX(outputs, 3600);
             }
         }
-        // MY + Vertical (even if shield is held) = 53
+        // MY + Vertical (even if shield is held)
         if (directions.vertical) {
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
+            SetLeftStickY(outputs, 5300);
             // MY Vertical Tilts
             if (inputs.a) {
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 36);
+                SetLeftStickY(outputs, 3600);
             }
         }
         if (directions.diagonal) {
-            // MY + q1/2/3/4 = 35 59
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
+            // MY + q1/2/3/4
+            SetLeftStick(outputs, 3500, 5300); // 56.56013°
             if (shield_button_pressed) {
-                // MY + L, R, LS, and MS + q1/2 = 38 70
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 38);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
-                // MY + L, R, LS, and MS + q3/4 = 40 68
-                if (directions.x == -1) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 40);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 68);
+                // MY + L, R, LS, and MS + q1/2
+                SetLeftStick(outputs, 3800, 7000); // 61.50436°
+                // MY + L, R, LS, and MS + q3/4
+                if (directions.x < 0) {
+                    SetLeftStick(outputs, 4000, 6800); // 59.53446°
                 }
             }
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            // (56.56) = 35 53
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
-            // (50.95) = 43 53
+            SetLeftStick(outputs, 3500, 5300); // 56.56013°
             if (inputs.c_down) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 43);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
+                SetLeftStick(outputs, 4300, 5300); // 50.94686°
             }
-            // (53.65) = 39 53
             if (inputs.c_left) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 49);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
+                SetLeftStick(outputs, 3900, 5300); // 53.65254°
             }
-            // (59.68) = 31 53
             if (inputs.c_up) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 31);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
+                SetLeftStick(outputs, 3100, 5300); // 59.67639°
             }
-            // (62.15) = 28 53
             if (inputs.c_right) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 28);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
+                SetLeftStick(outputs, 2800, 5300); // 62.15242°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                // (56.71) = 44 67
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
-                // (50.62) = 55 67
+                SetLeftStick(outputs, 4400, 6700); // 56.70644°
                 if (inputs.c_down) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 55);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
+                    SetLeftStick(outputs, 5500, 6700); // 50.61758°
                 }
-                // (53.82) = 49 67
                 if (inputs.c_left) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 49);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
+                    SetLeftStick(outputs, 4900, 6700); // 53.82038°
                 }
-                // (59.8) = 39 67
                 if (inputs.c_up) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 39);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
+                    SetLeftStick(outputs, 3900, 6700); // 59.79676°
                 }
-                // (62.42) = 35 67
                 if (inputs.c_right) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
+                    SetLeftStick(outputs, 3500, 6700); // 62.41797°
                 }
             }
 
             // MY Pivot Uptilt/Dtilt
             if (inputs.a) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 34);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 38);
+                SetLeftStick(outputs, 3400, 3800); // 48.17983°
             }
         }
     }
@@ -247,9 +198,7 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        // 5250 8500 = 42 68
-        outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 42);
-        outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.cy * 68);
+        SetRightStick(outputs, 4200, 6800); // 58.29857°
     }
 
     if (inputs.l) {
@@ -262,8 +211,7 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
-        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
+        SetRightStick(outputs, 0000, 0000);
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -81,7 +81,7 @@ void Ultimate::UpdateAnalogOutputs() {
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
+            SetAngledFSmash(12700, 5900); // 24.91802°
         }
 
         /* Up B angles */

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -1,8 +1,7 @@
 /* Ultimate profile by Taker */
 #include "modes/Ultimate.hpp"
 
-#define ANALOG_STICK_MIN 28
-#define ANALOG_STICK_MAX 228
+#define ANALOG_STICK_LENGTH 100
 
 Ultimate::Ultimate(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -144,7 +144,7 @@ void Ultimate::UpdateAnalogOutputs() {
                 SetLeftStick(4300, 5300); // 50.94686°
             }
             if (_inputs->c_left) {
-                SetLeftStick(3900, 5300); // 53.65254°
+                SetLeftStick(4900, 5300); // 47.24574°
             }
             if (_inputs->c_up) {
                 SetLeftStick(3100, 5300); // 59.67639°

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -1,9 +1,7 @@
 /* Ultimate profile by Taker */
 #include "modes/Ultimate.hpp"
 
-#define ANALOG_STICK_LENGTH 100
-
-Ultimate::Ultimate(socd::SocdType socd_type) : ControllerMode(socd_type) {
+Ultimate::Ultimate(socd::SocdType socd_type) : ControllerMode(socd_type, 100) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
         socd::SocdPair{&InputState::left,    &InputState::right  },
@@ -48,9 +46,6 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -180,7 +180,7 @@ void Ultimate::UpdateAnalogOutputs() {
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        SetRightStick(4200, 6800); // 58.29857°
+        SetCStick(4200, 6800); // 58.29857°
     }
 
     if (_inputs->l) {
@@ -193,7 +193,7 @@ void Ultimate::UpdateAnalogOutputs() {
 
     // Shut off c-stick when using dpad layer.
     if (_inputs->mod_x && _inputs->mod_y) {
-        SetRightStick(0000, 0000);
+        SetCStick(0000, 0000);
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -2,7 +2,6 @@
 #include "modes/Ultimate.hpp"
 
 #define ANALOG_STICK_MIN 28
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 228
 
 Ultimate::Ultimate(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -60,98 +60,98 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     if (inputs.mod_x) {
         // MX + Horizontal = 6625 = 53
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 53);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
             // Horizontal Shield tilt = 51
             if (shield_button_pressed) {
-                outputs.leftStickX = 128 + (directions.x * 51);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
             }
             // Horizontal Tilts = 36
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 36);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
             }
         }
         // MX + Vertical = 44
         if (directions.vertical) {
-            outputs.leftStickY = 128 + (directions.y * 44);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
             // Vertical Shield Tilt = 51
             if (shield_button_pressed) {
-                outputs.leftStickY = 128 + (directions.y * 51);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 51);
             }
         }
         if (directions.diagonal) {
             // MX + q1/2/3/4 = 53 35
-            outputs.leftStickX = 128 + (directions.x * 53);
-            outputs.leftStickY = 128 + (directions.y * 35);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
             if (shield_button_pressed) {
                 // MX + L, R, LS, and MS + q1/2/3/4 = 6375 3750 = 51 30
-                outputs.leftStickX = 128 + (directions.x * 51);
-                outputs.leftStickY = 128 + (directions.y * 30);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 30);
             }
         }
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            outputs.rightStickX = 128 + (directions.cx * 127);
-            outputs.rightStickY = 128 + (directions.y * 59);
+            outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 127);
+            outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.y * 59);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             // (33.44) = 53 35
-            outputs.leftStickX = 128 + (directions.x * 53);
-            outputs.leftStickY = 128 + (directions.y * 35);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
             // (39.05) = 53 43
             if (inputs.c_down) {
-                outputs.leftStickX = 128 + (directions.x * 53);
-                outputs.leftStickY = 128 + (directions.y * 43);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 43);
             }
             // (36.35) = 53 39
             if (inputs.c_left) {
-                outputs.leftStickX = 128 + (directions.x * 53);
-                outputs.leftStickY = 128 + (directions.y * 39);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 39);
             }
             // (30.32) = 56 41
             if (inputs.c_up) {
-                outputs.leftStickX = 128 + (directions.x * 53);
-                outputs.leftStickY = 128 + (directions.y * 31);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 31);
             }
             // (27.85) = 49 42
             if (inputs.c_right) {
-                outputs.leftStickX = 128 + (directions.x * 53);
-                outputs.leftStickY = 128 + (directions.y * 28);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 28);
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
                 // (33.29) = 67 44
-                outputs.leftStickX = 128 + (directions.x * 67);
-                outputs.leftStickY = 128 + (directions.y * 44);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
                 // (39.38) = 67 55
                 if (inputs.c_down) {
-                    outputs.leftStickX = 128 + (directions.x * 67);
-                    outputs.leftStickY = 128 + (directions.y * 55);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 55);
                 }
                 // (36.18) = 67 49
                 if (inputs.c_left) {
-                    outputs.leftStickX = 128 + (directions.x * 67);
-                    outputs.leftStickY = 128 + (directions.y * 49);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 49);
                 }
                 // (30.2) = 67 39
                 if (inputs.c_up) {
-                    outputs.leftStickX = 128 + (directions.x * 67);
-                    outputs.leftStickY = 128 + (directions.y * 39);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 39);
                 }
                 // (27.58) = 67 35
                 if (inputs.c_right) {
-                    outputs.leftStickX = 128 + (directions.x * 67);
-                    outputs.leftStickY = 128 + (directions.y * 35);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 67);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 35);
                 }
             }
 
             // Angled Ftilts
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 36);
-                outputs.leftStickY = 128 + (directions.y * 26);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 26);
             }
         }
     }
@@ -159,32 +159,32 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     if (inputs.mod_y) {
         // MY + Horizontal (even if shield is held) = 41
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 41);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 41);
             // MY Horizontal Tilts
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 36);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
             }
         }
         // MY + Vertical (even if shield is held) = 53
         if (directions.vertical) {
-            outputs.leftStickY = 128 + (directions.y * 53);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
             // MY Vertical Tilts
             if (inputs.a) {
-                outputs.leftStickY = 128 + (directions.y * 36);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 36);
             }
         }
         if (directions.diagonal) {
             // MY + q1/2/3/4 = 35 59
-            outputs.leftStickX = 128 + (directions.x * 35);
-            outputs.leftStickY = 128 + (directions.y * 53);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
             if (shield_button_pressed) {
                 // MY + L, R, LS, and MS + q1/2 = 38 70
-                outputs.leftStickX = 128 + (directions.x * 38);
-                outputs.leftStickY = 128 + (directions.y * 70);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 38);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
                 // MY + L, R, LS, and MS + q3/4 = 40 68
                 if (directions.x == -1) {
-                    outputs.leftStickX = 128 + (directions.x * 40);
-                    outputs.leftStickY = 128 + (directions.y * 68);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 40);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 68);
                 }
             }
         }
@@ -192,60 +192,60 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             // (56.56) = 35 53
-            outputs.leftStickX = 128 + (directions.x * 35);
-            outputs.leftStickY = 128 + (directions.y * 53);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
             // (50.95) = 43 53
             if (inputs.c_down) {
-                outputs.leftStickX = 128 + (directions.x * 43);
-                outputs.leftStickY = 128 + (directions.y * 53);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 43);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
             }
             // (53.65) = 39 53
             if (inputs.c_left) {
-                outputs.leftStickX = 128 + (directions.x * 49);
-                outputs.leftStickY = 128 + (directions.y * 53);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 49);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
             }
             // (59.68) = 31 53
             if (inputs.c_up) {
-                outputs.leftStickX = 128 + (directions.x * 31);
-                outputs.leftStickY = 128 + (directions.y * 53);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 31);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
             }
             // (62.15) = 28 53
             if (inputs.c_right) {
-                outputs.leftStickX = 128 + (directions.x * 28);
-                outputs.leftStickY = 128 + (directions.y * 53);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 28);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 53);
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
                 // (56.71) = 44 67
-                outputs.leftStickX = 128 + (directions.x * 44);
-                outputs.leftStickY = 128 + (directions.y * 67);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 44);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
                 // (50.62) = 55 67
                 if (inputs.c_down) {
-                    outputs.leftStickX = 128 + (directions.x * 55);
-                    outputs.leftStickY = 128 + (directions.y * 67);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 55);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
                 }
                 // (53.82) = 49 67
                 if (inputs.c_left) {
-                    outputs.leftStickX = 128 + (directions.x * 49);
-                    outputs.leftStickY = 128 + (directions.y * 67);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 49);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
                 }
                 // (59.8) = 39 67
                 if (inputs.c_up) {
-                    outputs.leftStickX = 128 + (directions.x * 39);
-                    outputs.leftStickY = 128 + (directions.y * 67);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 39);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
                 }
                 // (62.42) = 35 67
                 if (inputs.c_right) {
-                    outputs.leftStickX = 128 + (directions.x * 35);
-                    outputs.leftStickY = 128 + (directions.y * 67);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 67);
                 }
             }
 
             // MY Pivot Uptilt/Dtilt
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 34);
-                outputs.leftStickY = 128 + (directions.y * 38);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 34);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 38);
             }
         }
     }
@@ -254,8 +254,8 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
         // 5250 8500 = 42 68
-        outputs.rightStickX = 128 + (directions.cx * 42);
-        outputs.rightStickY = 128 + (directions.cy * 68);
+        outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 42);
+        outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.cy * 68);
     }
 
     if (inputs.l) {
@@ -268,8 +268,8 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = 128;
-        outputs.rightStickY = 128;
+        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
+        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -11,46 +11,46 @@ Ultimate::Ultimate(socd::SocdType socd_type) : ControllerMode(socd_type, 100) {
     };
 }
 
-void Ultimate::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->a = inputs.a;
-    outputs->b = inputs.b;
-    outputs->x = inputs.x;
-    outputs->y = inputs.y;
-    outputs->buttonR = inputs.z;
-    outputs->triggerLDigital = inputs.l;
-    outputs->triggerRDigital = inputs.r;
-    outputs->start = inputs.start;
+void Ultimate::UpdateDigitalOutputs() {
+    _outputs->a = _inputs->a;
+    _outputs->b = _inputs->b;
+    _outputs->x = _inputs->x;
+    _outputs->y = _inputs->y;
+    _outputs->buttonR = _inputs->z;
+    _outputs->triggerLDigital = _inputs->l;
+    _outputs->triggerRDigital = _inputs->r;
+    _outputs->start = _inputs->start;
 
     // D-Pad
-    if (inputs.mod_x && inputs.mod_y) {
-        outputs->dpadUp = inputs.c_up;
-        outputs->dpadDown = inputs.c_down;
-        outputs->dpadLeft = inputs.c_left;
-        outputs->dpadRight = inputs.c_right;
+    if (_inputs->mod_x && _inputs->mod_y) {
+        _outputs->dpadUp = _inputs->c_up;
+        _outputs->dpadDown = _inputs->c_down;
+        _outputs->dpadLeft = _inputs->c_left;
+        _outputs->dpadRight = _inputs->c_right;
     }
 
-    if (inputs.select)
-        outputs->dpadLeft = true;
-    if (inputs.home)
-        outputs->dpadRight = true;
+    if (_inputs->select)
+        _outputs->dpadLeft = true;
+    if (_inputs->home)
+        _outputs->dpadRight = true;
 }
 
-void Ultimate::UpdateAnalogOutputs(InputState &inputs) {
+void Ultimate::UpdateAnalogOutputs() {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.up,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->up,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 
-    bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
+    bool shield_button_pressed = _inputs->l || _inputs->r || _inputs->lightshield || _inputs->midshield;
 
-    if (inputs.mod_x) {
+    if (_inputs->mod_x) {
         // MX + Horizontal
         if (directions.horizontal) {
             SetLeftStickX(5300);
@@ -59,7 +59,7 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs) {
                 SetLeftStickX(5100);
             }
             // Horizontal Tilts
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStickX(3600);
             }
         }
@@ -81,55 +81,55 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs) {
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
+            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             SetLeftStick(5300, 3500); // 33.43987°
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(5300, 4300); // 39.05314°
             }
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(5300, 3900); // 36.34746°
             }
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(5300, 3100); // 30.32361°
             }
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(5300, 2800); // 27.84758°
             }
 
             /* Extended Up B Angles */
-            if (inputs.b) {
+            if (_inputs->b) {
                 SetLeftStick(6700, 4400); // 33.29356°
-                if (inputs.c_down) {
+                if (_inputs->c_down) {
                     SetLeftStick(6700, 5500); // 39.38242°
                 }
-                if (inputs.c_left) {
+                if (_inputs->c_left) {
                     SetLeftStick(6700, 4900); // 36.17962°
                 }
-                if (inputs.c_up) {
+                if (_inputs->c_up) {
                     SetLeftStick(6700, 3900); // 30.20324°
                 }
-                if (inputs.c_right) {
+                if (_inputs->c_right) {
                     SetLeftStick(6700, 3500); // 27.58203°
                 }
             }
 
             // Angled Ftilts
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStick(3600, 2600); // 35.83765°
             }
         }
     }
 
-    if (inputs.mod_y) {
+    if (_inputs->mod_y) {
         // MY + Horizontal (even if shield is held)
         if (directions.horizontal) {
             SetLeftStickX(4100);
             // MY Horizontal Tilts
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStickX(3600);
             }
         }
@@ -137,7 +137,7 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs) {
         if (directions.vertical) {
             SetLeftStickY(5300);
             // MY Vertical Tilts
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStickY(3600);
             }
         }
@@ -157,38 +157,38 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs) {
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             SetLeftStick(3500, 5300); // 56.56013°
-            if (inputs.c_down) {
+            if (_inputs->c_down) {
                 SetLeftStick(4300, 5300); // 50.94686°
             }
-            if (inputs.c_left) {
+            if (_inputs->c_left) {
                 SetLeftStick(3900, 5300); // 53.65254°
             }
-            if (inputs.c_up) {
+            if (_inputs->c_up) {
                 SetLeftStick(3100, 5300); // 59.67639°
             }
-            if (inputs.c_right) {
+            if (_inputs->c_right) {
                 SetLeftStick(2800, 5300); // 62.15242°
             }
 
             /* Extended Up B Angles */
-            if (inputs.b) {
+            if (_inputs->b) {
                 SetLeftStick(4400, 6700); // 56.70644°
-                if (inputs.c_down) {
+                if (_inputs->c_down) {
                     SetLeftStick(5500, 6700); // 50.61758°
                 }
-                if (inputs.c_left) {
+                if (_inputs->c_left) {
                     SetLeftStick(4900, 6700); // 53.82038°
                 }
-                if (inputs.c_up) {
+                if (_inputs->c_up) {
                     SetLeftStick(3900, 6700); // 59.79676°
                 }
-                if (inputs.c_right) {
+                if (_inputs->c_right) {
                     SetLeftStick(3500, 6700); // 62.41797°
                 }
             }
 
             // MY Pivot Uptilt/Dtilt
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStick(3400, 3800); // 48.17983°
             }
         }
@@ -200,22 +200,22 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs) {
         SetRightStick(4200, 6800); // 58.29857°
     }
 
-    if (inputs.l) {
-        outputs->triggerLAnalog = 140;
+    if (_inputs->l) {
+        _outputs->triggerLAnalog = 140;
     }
 
-    if (inputs.r) {
-        outputs->triggerRAnalog = 140;
+    if (_inputs->r) {
+        _outputs->triggerRAnalog = 140;
     }
 
     // Shut off c-stick when using dpad layer.
-    if (inputs.mod_x && inputs.mod_y) {
+    if (_inputs->mod_x && _inputs->mod_y) {
         SetRightStick(0000, 0000);
     }
 
     // Nunchuk overrides left stick.
-    if (inputs.nunchuk_connected) {
-        outputs->leftStickX = inputs.nunchuk_x;
-        outputs->leftStickY = inputs.nunchuk_y;
+    if (_inputs->nunchuk_connected) {
+        _outputs->leftStickX = _inputs->nunchuk_x;
+        _outputs->leftStickY = _inputs->nunchuk_y;
     }
 }

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -1,15 +1,8 @@
 /* Ultimate profile by Taker */
 #include "modes/Ultimate.hpp"
 
-Ultimate::Ultimate(socd::SocdType socd_type) : ControllerMode(socd_type, 100) {
-    _socd_pair_count = 4;
-    _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
-    };
-}
+Ultimate::Ultimate(socd::SocdType socd_type)
+    : PlatformFighter(socd_type, 100) { }
 
 void Ultimate::UpdateDigitalOutputs() {
     _outputs->a = _inputs->a;

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -11,31 +11,31 @@ Ultimate::Ultimate(socd::SocdType socd_type) : ControllerMode(socd_type, 100) {
     };
 }
 
-void Ultimate::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.a = inputs.a;
-    outputs.b = inputs.b;
-    outputs.x = inputs.x;
-    outputs.y = inputs.y;
-    outputs.buttonR = inputs.z;
-    outputs.triggerLDigital = inputs.l;
-    outputs.triggerRDigital = inputs.r;
-    outputs.start = inputs.start;
+void Ultimate::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->a = inputs.a;
+    outputs->b = inputs.b;
+    outputs->x = inputs.x;
+    outputs->y = inputs.y;
+    outputs->buttonR = inputs.z;
+    outputs->triggerLDigital = inputs.l;
+    outputs->triggerRDigital = inputs.r;
+    outputs->start = inputs.start;
 
     // D-Pad
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.dpadUp = inputs.c_up;
-        outputs.dpadDown = inputs.c_down;
-        outputs.dpadLeft = inputs.c_left;
-        outputs.dpadRight = inputs.c_right;
+        outputs->dpadUp = inputs.c_up;
+        outputs->dpadDown = inputs.c_down;
+        outputs->dpadLeft = inputs.c_left;
+        outputs->dpadRight = inputs.c_right;
     }
 
     if (inputs.select)
-        outputs.dpadLeft = true;
+        outputs->dpadLeft = true;
     if (inputs.home)
-        outputs.dpadRight = true;
+        outputs->dpadRight = true;
 }
 
-void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void Ultimate::UpdateAnalogOutputs(InputState &inputs) {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
         inputs.left,
@@ -45,8 +45,7 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 
     bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
@@ -54,73 +53,73 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     if (inputs.mod_x) {
         // MX + Horizontal
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 5300);
+            SetLeftStickX(5300);
             // Horizontal Shield tilt
             if (shield_button_pressed) {
-                SetLeftStickX(outputs, 5100);
+                SetLeftStickX(5100);
             }
             // Horizontal Tilts
             if (inputs.a) {
-                SetLeftStickX(outputs, 3600);
+                SetLeftStickX(3600);
             }
         }
         // MX + Vertical
         if (directions.vertical) {
-            SetLeftStickY(outputs, 4400);
+            SetLeftStickY(4400);
             if (shield_button_pressed) {
-                SetLeftStickY(outputs, 5100);
+                SetLeftStickY(5100);
             }
         }
         if (directions.diagonal) {
             // MX + q1/2/3/4
-            SetLeftStick(outputs, 5300, 3500); // 33.43987°
+            SetLeftStick(5300, 3500); // 33.43987°
             if (shield_button_pressed) {
                 // MX + L, R, LS, and MS + q1/2/3/4
-                SetLeftStick(outputs, 5100, 3000); // 30.46554°
+                SetLeftStick(5100, 3000); // 30.46554°
             }
         }
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
+            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 5300, 3500); // 33.43987°
+            SetLeftStick(5300, 3500); // 33.43987°
             if (inputs.c_down) {
-                SetLeftStick(outputs, 5300, 4300); // 39.05314°
+                SetLeftStick(5300, 4300); // 39.05314°
             }
             if (inputs.c_left) {
-                SetLeftStick(outputs, 5300, 3900); // 36.34746°
+                SetLeftStick(5300, 3900); // 36.34746°
             }
             if (inputs.c_up) {
-                SetLeftStick(outputs, 5300, 3100); // 30.32361°
+                SetLeftStick(5300, 3100); // 30.32361°
             }
             if (inputs.c_right) {
-                SetLeftStick(outputs, 5300, 2800); // 27.84758°
+                SetLeftStick(5300, 2800); // 27.84758°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                SetLeftStick(outputs, 6700, 4400); // 33.29356°
+                SetLeftStick(6700, 4400); // 33.29356°
                 if (inputs.c_down) {
-                    SetLeftStick(outputs, 6700, 5500); // 39.38242°
+                    SetLeftStick(6700, 5500); // 39.38242°
                 }
                 if (inputs.c_left) {
-                    SetLeftStick(outputs, 6700, 4900); // 36.17962°
+                    SetLeftStick(6700, 4900); // 36.17962°
                 }
                 if (inputs.c_up) {
-                    SetLeftStick(outputs, 6700, 3900); // 30.20324°
+                    SetLeftStick(6700, 3900); // 30.20324°
                 }
                 if (inputs.c_right) {
-                    SetLeftStick(outputs, 6700, 3500); // 27.58203°
+                    SetLeftStick(6700, 3500); // 27.58203°
                 }
             }
 
             // Angled Ftilts
             if (inputs.a) {
-                SetLeftStick(outputs, 3600, 2600); // 35.83765°
+                SetLeftStick(3600, 2600); // 35.83765°
             }
         }
     }
@@ -128,69 +127,69 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     if (inputs.mod_y) {
         // MY + Horizontal (even if shield is held)
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 4100);
+            SetLeftStickX(4100);
             // MY Horizontal Tilts
             if (inputs.a) {
-                SetLeftStickX(outputs, 3600);
+                SetLeftStickX(3600);
             }
         }
         // MY + Vertical (even if shield is held)
         if (directions.vertical) {
-            SetLeftStickY(outputs, 5300);
+            SetLeftStickY(5300);
             // MY Vertical Tilts
             if (inputs.a) {
-                SetLeftStickY(outputs, 3600);
+                SetLeftStickY(3600);
             }
         }
         if (directions.diagonal) {
             // MY + q1/2/3/4
-            SetLeftStick(outputs, 3500, 5300); // 56.56013°
+            SetLeftStick(3500, 5300); // 56.56013°
             if (shield_button_pressed) {
                 // MY + L, R, LS, and MS + q1/2
-                SetLeftStick(outputs, 3800, 7000); // 61.50436°
+                SetLeftStick(3800, 7000); // 61.50436°
                 // MY + L, R, LS, and MS + q3/4
                 if (directions.x < 0) {
-                    SetLeftStick(outputs, 4000, 6800); // 59.53446°
+                    SetLeftStick(4000, 6800); // 59.53446°
                 }
             }
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 3500, 5300); // 56.56013°
+            SetLeftStick(3500, 5300); // 56.56013°
             if (inputs.c_down) {
-                SetLeftStick(outputs, 4300, 5300); // 50.94686°
+                SetLeftStick(4300, 5300); // 50.94686°
             }
             if (inputs.c_left) {
-                SetLeftStick(outputs, 3900, 5300); // 53.65254°
+                SetLeftStick(3900, 5300); // 53.65254°
             }
             if (inputs.c_up) {
-                SetLeftStick(outputs, 3100, 5300); // 59.67639°
+                SetLeftStick(3100, 5300); // 59.67639°
             }
             if (inputs.c_right) {
-                SetLeftStick(outputs, 2800, 5300); // 62.15242°
+                SetLeftStick(2800, 5300); // 62.15242°
             }
 
             /* Extended Up B Angles */
             if (inputs.b) {
-                SetLeftStick(outputs, 4400, 6700); // 56.70644°
+                SetLeftStick(4400, 6700); // 56.70644°
                 if (inputs.c_down) {
-                    SetLeftStick(outputs, 5500, 6700); // 50.61758°
+                    SetLeftStick(5500, 6700); // 50.61758°
                 }
                 if (inputs.c_left) {
-                    SetLeftStick(outputs, 4900, 6700); // 53.82038°
+                    SetLeftStick(4900, 6700); // 53.82038°
                 }
                 if (inputs.c_up) {
-                    SetLeftStick(outputs, 3900, 6700); // 59.79676°
+                    SetLeftStick(3900, 6700); // 59.79676°
                 }
                 if (inputs.c_right) {
-                    SetLeftStick(outputs, 3500, 6700); // 62.41797°
+                    SetLeftStick(3500, 6700); // 62.41797°
                 }
             }
 
             // MY Pivot Uptilt/Dtilt
             if (inputs.a) {
-                SetLeftStick(outputs, 3400, 3800); // 48.17983°
+                SetLeftStick(3400, 3800); // 48.17983°
             }
         }
     }
@@ -198,25 +197,25 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        SetRightStick(outputs, 4200, 6800); // 58.29857°
+        SetRightStick(4200, 6800); // 58.29857°
     }
 
     if (inputs.l) {
-        outputs.triggerLAnalog = 140;
+        outputs->triggerLAnalog = 140;
     }
 
     if (inputs.r) {
-        outputs.triggerRAnalog = 140;
+        outputs->triggerRAnalog = 140;
     }
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        SetRightStick(outputs, 0000, 0000);
+        SetRightStick(0000, 0000);
     }
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs.leftStickX = inputs.nunchuk_x;
-        outputs.leftStickY = inputs.nunchuk_y;
+        outputs->leftStickX = inputs.nunchuk_x;
+        outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/extra/DarkSouls.cpp
+++ b/src/modes/extra/DarkSouls.cpp
@@ -3,60 +3,60 @@
 DarkSouls::DarkSouls(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
+        socd::SocdPair{ &InputState::left,   &InputState::right  },
         socd::SocdPair{ &InputState::down,   &InputState::mod_x  },
         socd::SocdPair{ &InputState::c_left, &InputState::c_right},
         socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
     };
 }
 
-void DarkSouls::UpdateDigitalOutputs(InputState &inputs) {
-    _outputs->y = inputs.y;
-    _outputs->x = inputs.r;
+void DarkSouls::UpdateDigitalOutputs() {
+    _outputs->y = _inputs->y;
+    _outputs->x = _inputs->r;
 
     // Base layer.
-    bool layer0 = !inputs.x && !inputs.nunchuk_c;
+    bool layer0 = !_inputs->x && !_inputs->nunchuk_c;
     // Secondary layer when X is held.
-    bool layerX = inputs.x && !inputs.nunchuk_c;
+    bool layerX = _inputs->x && !_inputs->nunchuk_c;
     // DPad layer when Nunchuk C is held.
-    bool layerC = inputs.nunchuk_c;
+    bool layerC = _inputs->nunchuk_c;
 
     if (layer0) {
-        _outputs->a = inputs.a;
-        _outputs->b = inputs.b;
-        _outputs->buttonR = inputs.z;
-        _outputs->buttonL = inputs.up;
-        _outputs->start = inputs.start | inputs.nunchuk_z;
+        _outputs->a = _inputs->a;
+        _outputs->b = _inputs->b;
+        _outputs->buttonR = _inputs->z;
+        _outputs->buttonL = _inputs->up;
+        _outputs->start = _inputs->start | _inputs->nunchuk_z;
     } else if (layerX) {
-        _outputs->rightStickClick = inputs.a;
-        _outputs->triggerRDigital = inputs.z;
-        _outputs->triggerLDigital = inputs.up;
-        _outputs->select = inputs.start;
+        _outputs->rightStickClick = _inputs->a;
+        _outputs->triggerRDigital = _inputs->z;
+        _outputs->triggerLDigital = _inputs->up;
+        _outputs->select = _inputs->start;
     } else if (layerC) {
-        _outputs->a = inputs.a;
-        _outputs->dpadLeft = inputs.b;
-        _outputs->dpadDown = inputs.x;
-        _outputs->dpadUp = inputs.z;
-        _outputs->dpadRight = inputs.up;
-        _outputs->select = inputs.nunchuk_z;
+        _outputs->a = _inputs->a;
+        _outputs->dpadLeft = _inputs->b;
+        _outputs->dpadDown = _inputs->x;
+        _outputs->dpadUp = _inputs->z;
+        _outputs->dpadRight = _inputs->up;
+        _outputs->select = _inputs->nunchuk_z;
     }
 }
 
-void DarkSouls::UpdateAnalogOutputs(InputState &inputs) {
+void DarkSouls::UpdateAnalogOutputs() {
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.mod_x,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->mod_x,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 
     // Nunchuk overrides left stick.
-    if (inputs.nunchuk_connected) {
-        _outputs->leftStickX = inputs.nunchuk_x;
-        _outputs->leftStickY = inputs.nunchuk_y;
+    if (_inputs->nunchuk_connected) {
+        _outputs->leftStickX = _inputs->nunchuk_x;
+        _outputs->leftStickY = _inputs->nunchuk_y;
     }
 }

--- a/src/modes/extra/DarkSouls.cpp
+++ b/src/modes/extra/DarkSouls.cpp
@@ -11,8 +11,8 @@ DarkSouls::DarkSouls(socd::SocdType socd_type) : ControllerMode(socd_type) {
 }
 
 void DarkSouls::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->y = inputs.y;
-    outputs->x = inputs.r;
+    _outputs->y = inputs.y;
+    _outputs->x = inputs.r;
 
     // Base layer.
     bool layer0 = !inputs.x && !inputs.nunchuk_c;
@@ -22,23 +22,23 @@ void DarkSouls::UpdateDigitalOutputs(InputState &inputs) {
     bool layerC = inputs.nunchuk_c;
 
     if (layer0) {
-        outputs->a = inputs.a;
-        outputs->b = inputs.b;
-        outputs->buttonR = inputs.z;
-        outputs->buttonL = inputs.up;
-        outputs->start = inputs.start | inputs.nunchuk_z;
+        _outputs->a = inputs.a;
+        _outputs->b = inputs.b;
+        _outputs->buttonR = inputs.z;
+        _outputs->buttonL = inputs.up;
+        _outputs->start = inputs.start | inputs.nunchuk_z;
     } else if (layerX) {
-        outputs->rightStickClick = inputs.a;
-        outputs->triggerRDigital = inputs.z;
-        outputs->triggerLDigital = inputs.up;
-        outputs->select = inputs.start;
+        _outputs->rightStickClick = inputs.a;
+        _outputs->triggerRDigital = inputs.z;
+        _outputs->triggerLDigital = inputs.up;
+        _outputs->select = inputs.start;
     } else if (layerC) {
-        outputs->a = inputs.a;
-        outputs->dpadLeft = inputs.b;
-        outputs->dpadDown = inputs.x;
-        outputs->dpadUp = inputs.z;
-        outputs->dpadRight = inputs.up;
-        outputs->select = inputs.nunchuk_z;
+        _outputs->a = inputs.a;
+        _outputs->dpadLeft = inputs.b;
+        _outputs->dpadDown = inputs.x;
+        _outputs->dpadUp = inputs.z;
+        _outputs->dpadRight = inputs.up;
+        _outputs->select = inputs.nunchuk_z;
     }
 }
 
@@ -56,7 +56,7 @@ void DarkSouls::UpdateAnalogOutputs(InputState &inputs) {
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs->leftStickX = inputs.nunchuk_x;
-        outputs->leftStickY = inputs.nunchuk_y;
+        _outputs->leftStickX = inputs.nunchuk_x;
+        _outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/extra/DarkSouls.cpp
+++ b/src/modes/extra/DarkSouls.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/DarkSouls.hpp"
 
 #define ANALOG_STICK_MIN 0
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
 DarkSouls::DarkSouls(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/extra/DarkSouls.cpp
+++ b/src/modes/extra/DarkSouls.cpp
@@ -1,7 +1,5 @@
 #include "modes/extra/DarkSouls.hpp"
 
-#define ANALOG_STICK_LENGTH 127
-
 DarkSouls::DarkSouls(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
@@ -54,9 +52,6 @@ void DarkSouls::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 

--- a/src/modes/extra/DarkSouls.cpp
+++ b/src/modes/extra/DarkSouls.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/DarkSouls.hpp"
 
-#define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_MAX 255
+#define ANALOG_STICK_LENGTH 127
 
 DarkSouls::DarkSouls(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/extra/DarkSouls.cpp
+++ b/src/modes/extra/DarkSouls.cpp
@@ -1,6 +1,6 @@
 #include "modes/extra/DarkSouls.hpp"
 
-#define ANALOG_STICK_MIN 0
+#define ANALOG_STICK_MIN 1
 #define ANALOG_STICK_MAX 255
 
 DarkSouls::DarkSouls(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/extra/DarkSouls.cpp
+++ b/src/modes/extra/DarkSouls.cpp
@@ -10,9 +10,9 @@ DarkSouls::DarkSouls(socd::SocdType socd_type) : ControllerMode(socd_type) {
     };
 }
 
-void DarkSouls::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.y = inputs.y;
-    outputs.x = inputs.r;
+void DarkSouls::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->y = inputs.y;
+    outputs->x = inputs.r;
 
     // Base layer.
     bool layer0 = !inputs.x && !inputs.nunchuk_c;
@@ -22,27 +22,27 @@ void DarkSouls::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
     bool layerC = inputs.nunchuk_c;
 
     if (layer0) {
-        outputs.a = inputs.a;
-        outputs.b = inputs.b;
-        outputs.buttonR = inputs.z;
-        outputs.buttonL = inputs.up;
-        outputs.start = inputs.start | inputs.nunchuk_z;
+        outputs->a = inputs.a;
+        outputs->b = inputs.b;
+        outputs->buttonR = inputs.z;
+        outputs->buttonL = inputs.up;
+        outputs->start = inputs.start | inputs.nunchuk_z;
     } else if (layerX) {
-        outputs.rightStickClick = inputs.a;
-        outputs.triggerRDigital = inputs.z;
-        outputs.triggerLDigital = inputs.up;
-        outputs.select = inputs.start;
+        outputs->rightStickClick = inputs.a;
+        outputs->triggerRDigital = inputs.z;
+        outputs->triggerLDigital = inputs.up;
+        outputs->select = inputs.start;
     } else if (layerC) {
-        outputs.a = inputs.a;
-        outputs.dpadLeft = inputs.b;
-        outputs.dpadDown = inputs.x;
-        outputs.dpadUp = inputs.z;
-        outputs.dpadRight = inputs.up;
-        outputs.select = inputs.nunchuk_z;
+        outputs->a = inputs.a;
+        outputs->dpadLeft = inputs.b;
+        outputs->dpadDown = inputs.x;
+        outputs->dpadUp = inputs.z;
+        outputs->dpadRight = inputs.up;
+        outputs->select = inputs.nunchuk_z;
     }
 }
 
-void DarkSouls::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void DarkSouls::UpdateAnalogOutputs(InputState &inputs) {
     UpdateDirections(
         inputs.left,
         inputs.right,
@@ -51,13 +51,12 @@ void DarkSouls::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs.leftStickX = inputs.nunchuk_x;
-        outputs.leftStickY = inputs.nunchuk_y;
+        outputs->leftStickX = inputs.nunchuk_x;
+        outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/extra/HollowKnight.cpp
+++ b/src/modes/extra/HollowKnight.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/HollowKnight.hpp"
 
-#define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_MAX 255
+#define ANALOG_STICK_LENGTH 127
 
 HollowKnight::HollowKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/extra/HollowKnight.cpp
+++ b/src/modes/extra/HollowKnight.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/HollowKnight.hpp"
 
 #define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
 HollowKnight::HollowKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/extra/HollowKnight.cpp
+++ b/src/modes/extra/HollowKnight.cpp
@@ -11,17 +11,17 @@ HollowKnight::HollowKnight(socd::SocdType socd_type) : ControllerMode(socd_type)
 }
 
 void HollowKnight::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->a = inputs.a; // Attack
-    outputs->b = inputs.b; // Dash
-    outputs->x = inputs.x; // Jump
-    outputs->y = inputs.mod_y; // Spell
-    outputs->triggerLDigital = inputs.r; // Focus/cast
-    outputs->triggerRDigital = inputs.z;
-    outputs->buttonR = inputs.up; // Dream nail
+    _outputs->a = inputs.a; // Attack
+    _outputs->b = inputs.b; // Dash
+    _outputs->x = inputs.x; // Jump
+    _outputs->y = inputs.mod_y; // Spell
+    _outputs->triggerLDigital = inputs.r; // Focus/cast
+    _outputs->triggerRDigital = inputs.z;
+    _outputs->buttonR = inputs.up; // Dream nail
 
-    outputs->buttonL = inputs.lightshield; // Map
-    outputs->select = inputs.midshield; // Inventory
-    outputs->start = inputs.start; // Pause
+    _outputs->buttonL = inputs.lightshield; // Map
+    _outputs->select = inputs.midshield; // Inventory
+    _outputs->start = inputs.start; // Pause
 }
 
 void HollowKnight::UpdateAnalogOutputs(InputState &inputs) {

--- a/src/modes/extra/HollowKnight.cpp
+++ b/src/modes/extra/HollowKnight.cpp
@@ -10,21 +10,21 @@ HollowKnight::HollowKnight(socd::SocdType socd_type) : ControllerMode(socd_type)
     };
 }
 
-void HollowKnight::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.a = inputs.a; // Attack
-    outputs.b = inputs.b; // Dash
-    outputs.x = inputs.x; // Jump
-    outputs.y = inputs.mod_y; // Spell
-    outputs.triggerLDigital = inputs.r; // Focus/cast
-    outputs.triggerRDigital = inputs.z;
-    outputs.buttonR = inputs.up; // Dream nail
+void HollowKnight::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->a = inputs.a; // Attack
+    outputs->b = inputs.b; // Dash
+    outputs->x = inputs.x; // Jump
+    outputs->y = inputs.mod_y; // Spell
+    outputs->triggerLDigital = inputs.r; // Focus/cast
+    outputs->triggerRDigital = inputs.z;
+    outputs->buttonR = inputs.up; // Dream nail
 
-    outputs.buttonL = inputs.lightshield; // Map
-    outputs.select = inputs.midshield; // Inventory
-    outputs.start = inputs.start; // Pause
+    outputs->buttonL = inputs.lightshield; // Map
+    outputs->select = inputs.midshield; // Inventory
+    outputs->start = inputs.start; // Pause
 }
 
-void HollowKnight::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void HollowKnight::UpdateAnalogOutputs(InputState &inputs) {
     UpdateDirections(
         inputs.left,
         inputs.right,
@@ -33,7 +33,6 @@ void HollowKnight::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs)
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 }

--- a/src/modes/extra/HollowKnight.cpp
+++ b/src/modes/extra/HollowKnight.cpp
@@ -1,7 +1,5 @@
 #include "modes/extra/HollowKnight.hpp"
 
-#define ANALOG_STICK_LENGTH 127
-
 HollowKnight::HollowKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
@@ -36,9 +34,6 @@ void HollowKnight::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs)
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 }

--- a/src/modes/extra/HollowKnight.cpp
+++ b/src/modes/extra/HollowKnight.cpp
@@ -3,36 +3,36 @@
 HollowKnight::HollowKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
+        socd::SocdPair{ &InputState::left,   &InputState::right  },
         socd::SocdPair{ &InputState::down,   &InputState::mod_x  },
         socd::SocdPair{ &InputState::c_left, &InputState::c_right},
         socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
     };
 }
 
-void HollowKnight::UpdateDigitalOutputs(InputState &inputs) {
-    _outputs->a = inputs.a; // Attack
-    _outputs->b = inputs.b; // Dash
-    _outputs->x = inputs.x; // Jump
-    _outputs->y = inputs.mod_y; // Spell
-    _outputs->triggerLDigital = inputs.r; // Focus/cast
-    _outputs->triggerRDigital = inputs.z;
-    _outputs->buttonR = inputs.up; // Dream nail
+void HollowKnight::UpdateDigitalOutputs() {
+    _outputs->a = _inputs->a; // Attack
+    _outputs->b = _inputs->b; // Dash
+    _outputs->x = _inputs->x; // Jump
+    _outputs->y = _inputs->mod_y; // Spell
+    _outputs->triggerLDigital = _inputs->r; // Focus/cast
+    _outputs->triggerRDigital = _inputs->z;
+    _outputs->buttonR = _inputs->up; // Dream nail
 
-    _outputs->buttonL = inputs.lightshield; // Map
-    _outputs->select = inputs.midshield; // Inventory
-    _outputs->start = inputs.start; // Pause
+    _outputs->buttonL = _inputs->lightshield; // Map
+    _outputs->select = _inputs->midshield; // Inventory
+    _outputs->start = _inputs->start; // Pause
 }
 
-void HollowKnight::UpdateAnalogOutputs(InputState &inputs) {
+void HollowKnight::UpdateAnalogOutputs() {
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.mod_x,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->mod_x,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 }

--- a/src/modes/extra/MKWii.cpp
+++ b/src/modes/extra/MKWii.cpp
@@ -10,22 +10,22 @@ MKWii::MKWii(socd::SocdType socd_type) : ControllerMode(socd_type) {
     };
 }
 
-void MKWii::UpdateDigitalOutputs(InputState &inputs) {
-    _outputs->a = inputs.b;
-    _outputs->b = inputs.x;
-    _outputs->triggerLDigital = inputs.z;
-    _outputs->buttonR = inputs.up;
-    _outputs->dpadUp = inputs.a;
-    _outputs->start = inputs.start;
+void MKWii::UpdateDigitalOutputs() {
+    _outputs->a = _inputs->b;
+    _outputs->b = _inputs->x;
+    _outputs->triggerLDigital = _inputs->z;
+    _outputs->buttonR = _inputs->up;
+    _outputs->dpadUp = _inputs->a;
+    _outputs->start = _inputs->start;
 }
 
-void MKWii::UpdateAnalogOutputs(InputState &inputs) {
-    bool up = inputs.down || inputs.mod_x || inputs.mod_y;
+void MKWii::UpdateAnalogOutputs() {
+    bool up = _inputs->down || _inputs->mod_x || _inputs->mod_y;
 
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.l,
+        _inputs->left,
+        _inputs->right,
+        _inputs->l,
         up,
         false,
         false,
@@ -33,13 +33,13 @@ void MKWii::UpdateAnalogOutputs(InputState &inputs) {
         false
     );
 
-    if (inputs.z) {
+    if (_inputs->z) {
         _outputs->triggerLAnalog = 140;
     }
 
     // Nunchuk overrides left stick.
-    if (inputs.nunchuk_connected) {
-        _outputs->leftStickX = inputs.nunchuk_x;
-        _outputs->leftStickY = inputs.nunchuk_y;
+    if (_inputs->nunchuk_connected) {
+        _outputs->leftStickX = _inputs->nunchuk_x;
+        _outputs->leftStickY = _inputs->nunchuk_y;
     }
 }

--- a/src/modes/extra/MKWii.cpp
+++ b/src/modes/extra/MKWii.cpp
@@ -10,16 +10,16 @@ MKWii::MKWii(socd::SocdType socd_type) : ControllerMode(socd_type) {
     };
 }
 
-void MKWii::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.a = inputs.b;
-    outputs.b = inputs.x;
-    outputs.triggerLDigital = inputs.z;
-    outputs.buttonR = inputs.up;
-    outputs.dpadUp = inputs.a;
-    outputs.start = inputs.start;
+void MKWii::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->a = inputs.b;
+    outputs->b = inputs.x;
+    outputs->triggerLDigital = inputs.z;
+    outputs->buttonR = inputs.up;
+    outputs->dpadUp = inputs.a;
+    outputs->start = inputs.start;
 }
 
-void MKWii::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void MKWii::UpdateAnalogOutputs(InputState &inputs) {
     bool up = inputs.down || inputs.mod_x || inputs.mod_y;
 
     UpdateDirections(
@@ -30,17 +30,16 @@ void MKWii::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         false,
         false,
         false,
-        false,
-        outputs
+        false
     );
 
     if (inputs.z) {
-        outputs.triggerLAnalog = 140;
+        outputs->triggerLAnalog = 140;
     }
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs.leftStickX = inputs.nunchuk_x;
-        outputs.leftStickY = inputs.nunchuk_y;
+        outputs->leftStickX = inputs.nunchuk_x;
+        outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/extra/MKWii.cpp
+++ b/src/modes/extra/MKWii.cpp
@@ -11,12 +11,12 @@ MKWii::MKWii(socd::SocdType socd_type) : ControllerMode(socd_type) {
 }
 
 void MKWii::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->a = inputs.b;
-    outputs->b = inputs.x;
-    outputs->triggerLDigital = inputs.z;
-    outputs->buttonR = inputs.up;
-    outputs->dpadUp = inputs.a;
-    outputs->start = inputs.start;
+    _outputs->a = inputs.b;
+    _outputs->b = inputs.x;
+    _outputs->triggerLDigital = inputs.z;
+    _outputs->buttonR = inputs.up;
+    _outputs->dpadUp = inputs.a;
+    _outputs->start = inputs.start;
 }
 
 void MKWii::UpdateAnalogOutputs(InputState &inputs) {
@@ -34,12 +34,12 @@ void MKWii::UpdateAnalogOutputs(InputState &inputs) {
     );
 
     if (inputs.z) {
-        outputs->triggerLAnalog = 140;
+        _outputs->triggerLAnalog = 140;
     }
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs->leftStickX = inputs.nunchuk_x;
-        outputs->leftStickY = inputs.nunchuk_y;
+        _outputs->leftStickX = inputs.nunchuk_x;
+        _outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/extra/MKWii.cpp
+++ b/src/modes/extra/MKWii.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/MKWii.hpp"
 
 #define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
 MKWii::MKWii(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/extra/MKWii.cpp
+++ b/src/modes/extra/MKWii.cpp
@@ -1,7 +1,5 @@
 #include "modes/extra/MKWii.hpp"
 
-#define ANALOG_STICK_LENGTH 127
-
 MKWii::MKWii(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
@@ -33,9 +31,6 @@ void MKWii::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         false,
         false,
         false,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 

--- a/src/modes/extra/MKWii.cpp
+++ b/src/modes/extra/MKWii.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/MKWii.hpp"
 
-#define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_MAX 255
+#define ANALOG_STICK_LENGTH 127
 
 MKWii::MKWii(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/extra/RocketLeague.cpp
+++ b/src/modes/extra/RocketLeague.cpp
@@ -65,8 +65,6 @@ void RocketLeague::UpdateAnalogOutputs() {
     if (_inputs->mod_y) {
         if (directions.diagonal) {
             _outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
-            // outputs->leftStickY =
-            // ANALOG_STICK_NEUTRAL + (directions.y * 76);
         } else if (directions.horizontal) {
             _outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
         } else if (directions.vertical) {

--- a/src/modes/extra/RocketLeague.cpp
+++ b/src/modes/extra/RocketLeague.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/RocketLeague.hpp"
 
-#define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_MAX 255
+#define ANALOG_STICK_LENGTH 127
 
 RocketLeague::RocketLeague(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 3;

--- a/src/modes/extra/RocketLeague.cpp
+++ b/src/modes/extra/RocketLeague.cpp
@@ -1,6 +1,6 @@
 #include "modes/extra/RocketLeague.hpp"
 
-#define ANALOG_STICK_MIN 0
+#define ANALOG_STICK_MIN 1
 #define ANALOG_STICK_MAX 255
 
 RocketLeague::RocketLeague(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/extra/RocketLeague.cpp
+++ b/src/modes/extra/RocketLeague.cpp
@@ -16,40 +16,40 @@ void RocketLeague::HandleSocd(InputState &inputs) {
     InputMode::HandleSocd(inputs);
 }
 
-void RocketLeague::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.a = inputs.a;
-    outputs.b = inputs.b;
-    outputs.x = inputs.midshield;
-    outputs.y = inputs.up;
-    outputs.buttonL = inputs.l;
-    outputs.buttonR = inputs.lightshield;
-    outputs.triggerLDigital = inputs.z;
-    outputs.triggerRDigital = inputs.x;
-    outputs.leftStickClick = inputs.r;
+void RocketLeague::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->a = inputs.a;
+    outputs->b = inputs.b;
+    outputs->x = inputs.midshield;
+    outputs->y = inputs.up;
+    outputs->buttonL = inputs.l;
+    outputs->buttonR = inputs.lightshield;
+    outputs->triggerLDigital = inputs.z;
+    outputs->triggerRDigital = inputs.x;
+    outputs->leftStickClick = inputs.r;
 
     // Hold accelerate and reverse simultaneously for rear view.
     if (inputs.z && inputs.x) {
-        outputs.rightStickClick = true;
+        outputs->rightStickClick = true;
         // Override (deactivate) accelerator.
-        outputs.triggerRDigital = false;
+        outputs->triggerRDigital = false;
     }
 
     // MX + Start = Select
     if (inputs.mod_x)
-        outputs.select = inputs.start;
+        outputs->select = inputs.start;
     else
-        outputs.start = inputs.start;
+        outputs->start = inputs.start;
 
     // D-Pad
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.dpadUp = inputs.c_up;
-        outputs.dpadDown = inputs.c_down;
-        outputs.dpadLeft = inputs.c_left;
-        outputs.dpadRight = inputs.c_right;
+        outputs->dpadUp = inputs.c_up;
+        outputs->dpadDown = inputs.c_down;
+        outputs->dpadLeft = inputs.c_left;
+        outputs->dpadRight = inputs.c_right;
     }
 }
 
-void RocketLeague::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void RocketLeague::UpdateAnalogOutputs(InputState &inputs) {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
         inputs.left,
@@ -59,34 +59,33 @@ void RocketLeague::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs)
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 
     if (inputs.mod_y) {
         if (directions.diagonal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
-            // outputs.leftStickY =
+            outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
+            // outputs->leftStickY =
             // ANALOG_STICK_NEUTRAL + (directions.y * 76);
         } else if (directions.horizontal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
+            outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
         } else if (directions.vertical) {
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 76);
+            outputs->leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 76);
         }
     } else if (directions.diagonal) {
         // Good speed flip angle with no mods.
-        outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
+        outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
     }
 
     // Shut off right stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
-        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
+        outputs->rightStickX = ANALOG_STICK_NEUTRAL;
+        outputs->rightStickY = ANALOG_STICK_NEUTRAL;
     }
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs.leftStickX = inputs.nunchuk_x;
-        outputs.leftStickY = inputs.nunchuk_y;
+        outputs->leftStickX = inputs.nunchuk_x;
+        outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/extra/RocketLeague.cpp
+++ b/src/modes/extra/RocketLeague.cpp
@@ -1,7 +1,5 @@
 #include "modes/extra/RocketLeague.hpp"
 
-#define ANALOG_STICK_LENGTH 127
-
 RocketLeague::RocketLeague(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 3;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
@@ -62,9 +60,6 @@ void RocketLeague::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs)
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 

--- a/src/modes/extra/RocketLeague.cpp
+++ b/src/modes/extra/RocketLeague.cpp
@@ -9,83 +9,83 @@ RocketLeague::RocketLeague(socd::SocdType socd_type) : ControllerMode(socd_type)
     };
 }
 
-void RocketLeague::HandleSocd(InputState &inputs) {
-    if (inputs.mod_x && inputs.down) {
-        inputs.down = false;
+void RocketLeague::HandleSocd() {
+    if (_inputs->mod_x && _inputs->down) {
+        _inputs->down = false;
     }
-    InputMode::HandleSocd(inputs);
+    InputMode::HandleSocd();
 }
 
-void RocketLeague::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->a = inputs.a;
-    outputs->b = inputs.b;
-    outputs->x = inputs.midshield;
-    outputs->y = inputs.up;
-    outputs->buttonL = inputs.l;
-    outputs->buttonR = inputs.lightshield;
-    outputs->triggerLDigital = inputs.z;
-    outputs->triggerRDigital = inputs.x;
-    outputs->leftStickClick = inputs.r;
+void RocketLeague::UpdateDigitalOutputs() {
+    _outputs->a = _inputs->a;
+    _outputs->b = _inputs->b;
+    _outputs->x = _inputs->midshield;
+    _outputs->y = _inputs->up;
+    _outputs->buttonL = _inputs->l;
+    _outputs->buttonR = _inputs->lightshield;
+    _outputs->triggerLDigital = _inputs->z;
+    _outputs->triggerRDigital = _inputs->x;
+    _outputs->leftStickClick = _inputs->r;
 
     // Hold accelerate and reverse simultaneously for rear view.
-    if (inputs.z && inputs.x) {
-        outputs->rightStickClick = true;
+    if (_inputs->z && _inputs->x) {
+        _outputs->rightStickClick = true;
         // Override (deactivate) accelerator.
-        outputs->triggerRDigital = false;
+        _outputs->triggerRDigital = false;
     }
 
     // MX + Start = Select
-    if (inputs.mod_x)
-        outputs->select = inputs.start;
+    if (_inputs->mod_x)
+        _outputs->select = _inputs->start;
     else
-        outputs->start = inputs.start;
+        _outputs->start = _inputs->start;
 
     // D-Pad
-    if (inputs.mod_x && inputs.mod_y) {
-        outputs->dpadUp = inputs.c_up;
-        outputs->dpadDown = inputs.c_down;
-        outputs->dpadLeft = inputs.c_left;
-        outputs->dpadRight = inputs.c_right;
+    if (_inputs->mod_x && _inputs->mod_y) {
+        _outputs->dpadUp = _inputs->c_up;
+        _outputs->dpadDown = _inputs->c_down;
+        _outputs->dpadLeft = _inputs->c_left;
+        _outputs->dpadRight = _inputs->c_right;
     }
 }
 
-void RocketLeague::UpdateAnalogOutputs(InputState &inputs) {
+void RocketLeague::UpdateAnalogOutputs() {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.mod_x,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->mod_x,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 
-    if (inputs.mod_y) {
+    if (_inputs->mod_y) {
         if (directions.diagonal) {
-            outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
+            _outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
             // outputs->leftStickY =
             // ANALOG_STICK_NEUTRAL + (directions.y * 76);
         } else if (directions.horizontal) {
-            outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
+            _outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 35);
         } else if (directions.vertical) {
-            outputs->leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 76);
+            _outputs->leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 76);
         }
     } else if (directions.diagonal) {
         // Good speed flip angle with no mods.
-        outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
+        _outputs->leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 70);
     }
 
     // Shut off right stick when using dpad layer.
-    if (inputs.mod_x && inputs.mod_y) {
-        outputs->rightStickX = ANALOG_STICK_NEUTRAL;
-        outputs->rightStickY = ANALOG_STICK_NEUTRAL;
+    if (_inputs->mod_x && _inputs->mod_y) {
+        _outputs->rightStickX = ANALOG_STICK_NEUTRAL;
+        _outputs->rightStickY = ANALOG_STICK_NEUTRAL;
     }
 
     // Nunchuk overrides left stick.
-    if (inputs.nunchuk_connected) {
-        outputs->leftStickX = inputs.nunchuk_x;
-        outputs->leftStickY = inputs.nunchuk_y;
+    if (_inputs->nunchuk_connected) {
+        _outputs->leftStickX = _inputs->nunchuk_x;
+        _outputs->leftStickY = _inputs->nunchuk_y;
     }
 }

--- a/src/modes/extra/RocketLeague.cpp
+++ b/src/modes/extra/RocketLeague.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/RocketLeague.hpp"
 
 #define ANALOG_STICK_MIN 0
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
 RocketLeague::RocketLeague(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/extra/SaltAndSanctuary.cpp
+++ b/src/modes/extra/SaltAndSanctuary.cpp
@@ -3,42 +3,42 @@
 SaltAndSanctuary::SaltAndSanctuary(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
+        socd::SocdPair{ &InputState::left,   &InputState::right  },
         socd::SocdPair{ &InputState::down,   &InputState::mod_x  },
         socd::SocdPair{ &InputState::c_left, &InputState::c_right},
         socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
     };
 }
 
-void SaltAndSanctuary::UpdateDigitalOutputs(InputState &inputs) {
-    _outputs->dpadRight = inputs.l; // Block
-    _outputs->b = inputs.b; // Roll
-    _outputs->a = inputs.a; // Attack
-    _outputs->y = inputs.z; // Strong
-    _outputs->dpadDown = inputs.mod_y; // Use
-    _outputs->x = inputs.x; // Jump
+void SaltAndSanctuary::UpdateDigitalOutputs() {
+    _outputs->dpadRight = _inputs->l; // Block
+    _outputs->b = _inputs->b; // Roll
+    _outputs->a = _inputs->a; // Attack
+    _outputs->y = _inputs->z; // Strong
+    _outputs->dpadDown = _inputs->mod_y; // Use
+    _outputs->x = _inputs->x; // Jump
 
-    _outputs->buttonL = inputs.r; // Previous item
-    _outputs->buttonR = inputs.y; // Next item
-    _outputs->triggerLDigital = inputs.lightshield; // Use item
+    _outputs->buttonL = _inputs->r; // Previous item
+    _outputs->buttonR = _inputs->y; // Next item
+    _outputs->triggerLDigital = _inputs->lightshield; // Use item
 
-    _outputs->triggerRDigital = inputs.midshield; // Use torch
+    _outputs->triggerRDigital = _inputs->midshield; // Use torch
 
-    _outputs->dpadLeft = inputs.up; // Switch loadout
+    _outputs->dpadLeft = _inputs->up; // Switch loadout
 
-    _outputs->start = inputs.start; // Inventory
+    _outputs->start = _inputs->start; // Inventory
 }
 
-void SaltAndSanctuary::UpdateAnalogOutputs(InputState &inputs) {
+void SaltAndSanctuary::UpdateAnalogOutputs() {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.mod_x,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->mod_x,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 }

--- a/src/modes/extra/SaltAndSanctuary.cpp
+++ b/src/modes/extra/SaltAndSanctuary.cpp
@@ -10,26 +10,26 @@ SaltAndSanctuary::SaltAndSanctuary(socd::SocdType socd_type) : ControllerMode(so
     };
 }
 
-void SaltAndSanctuary::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.dpadRight = inputs.l; // Block
-    outputs.b = inputs.b; // Roll
-    outputs.a = inputs.a; // Attack
-    outputs.y = inputs.z; // Strong
-    outputs.dpadDown = inputs.mod_y; // Use
-    outputs.x = inputs.x; // Jump
+void SaltAndSanctuary::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->dpadRight = inputs.l; // Block
+    outputs->b = inputs.b; // Roll
+    outputs->a = inputs.a; // Attack
+    outputs->y = inputs.z; // Strong
+    outputs->dpadDown = inputs.mod_y; // Use
+    outputs->x = inputs.x; // Jump
 
-    outputs.buttonL = inputs.r; // Previous item
-    outputs.buttonR = inputs.y; // Next item
-    outputs.triggerLDigital = inputs.lightshield; // Use item
+    outputs->buttonL = inputs.r; // Previous item
+    outputs->buttonR = inputs.y; // Next item
+    outputs->triggerLDigital = inputs.lightshield; // Use item
 
-    outputs.triggerRDigital = inputs.midshield; // Use torch
+    outputs->triggerRDigital = inputs.midshield; // Use torch
 
-    outputs.dpadLeft = inputs.up; // Switch loadout
+    outputs->dpadLeft = inputs.up; // Switch loadout
 
-    outputs.start = inputs.start; // Inventory
+    outputs->start = inputs.start; // Inventory
 }
 
-void SaltAndSanctuary::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void SaltAndSanctuary::UpdateAnalogOutputs(InputState &inputs) {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
         inputs.left,
@@ -39,7 +39,6 @@ void SaltAndSanctuary::UpdateAnalogOutputs(InputState &inputs, OutputState &outp
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 }

--- a/src/modes/extra/SaltAndSanctuary.cpp
+++ b/src/modes/extra/SaltAndSanctuary.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/SaltAndSanctuary.hpp"
 
 #define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
 SaltAndSanctuary::SaltAndSanctuary(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/extra/SaltAndSanctuary.cpp
+++ b/src/modes/extra/SaltAndSanctuary.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/SaltAndSanctuary.hpp"
 
-#define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_MAX 255
+#define ANALOG_STICK_LENGTH 127
 
 SaltAndSanctuary::SaltAndSanctuary(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/extra/SaltAndSanctuary.cpp
+++ b/src/modes/extra/SaltAndSanctuary.cpp
@@ -1,7 +1,5 @@
 #include "modes/extra/SaltAndSanctuary.hpp"
 
-#define ANALOG_STICK_LENGTH 127
-
 SaltAndSanctuary::SaltAndSanctuary(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
@@ -42,9 +40,6 @@ void SaltAndSanctuary::UpdateAnalogOutputs(InputState &inputs, OutputState &outp
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 }

--- a/src/modes/extra/SaltAndSanctuary.cpp
+++ b/src/modes/extra/SaltAndSanctuary.cpp
@@ -11,22 +11,22 @@ SaltAndSanctuary::SaltAndSanctuary(socd::SocdType socd_type) : ControllerMode(so
 }
 
 void SaltAndSanctuary::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->dpadRight = inputs.l; // Block
-    outputs->b = inputs.b; // Roll
-    outputs->a = inputs.a; // Attack
-    outputs->y = inputs.z; // Strong
-    outputs->dpadDown = inputs.mod_y; // Use
-    outputs->x = inputs.x; // Jump
+    _outputs->dpadRight = inputs.l; // Block
+    _outputs->b = inputs.b; // Roll
+    _outputs->a = inputs.a; // Attack
+    _outputs->y = inputs.z; // Strong
+    _outputs->dpadDown = inputs.mod_y; // Use
+    _outputs->x = inputs.x; // Jump
 
-    outputs->buttonL = inputs.r; // Previous item
-    outputs->buttonR = inputs.y; // Next item
-    outputs->triggerLDigital = inputs.lightshield; // Use item
+    _outputs->buttonL = inputs.r; // Previous item
+    _outputs->buttonR = inputs.y; // Next item
+    _outputs->triggerLDigital = inputs.lightshield; // Use item
 
-    outputs->triggerRDigital = inputs.midshield; // Use torch
+    _outputs->triggerRDigital = inputs.midshield; // Use torch
 
-    outputs->dpadLeft = inputs.up; // Switch loadout
+    _outputs->dpadLeft = inputs.up; // Switch loadout
 
-    outputs->start = inputs.start; // Inventory
+    _outputs->start = inputs.start; // Inventory
 }
 
 void SaltAndSanctuary::UpdateAnalogOutputs(InputState &inputs) {

--- a/src/modes/extra/ShovelKnight.cpp
+++ b/src/modes/extra/ShovelKnight.cpp
@@ -1,7 +1,5 @@
 #include "modes/extra/ShovelKnight.hpp"
 
-#define ANALOG_STICK_LENGTH 127
-
 ShovelKnight::ShovelKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
@@ -39,9 +37,6 @@ void ShovelKnight::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs)
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 }

--- a/src/modes/extra/ShovelKnight.cpp
+++ b/src/modes/extra/ShovelKnight.cpp
@@ -3,39 +3,39 @@
 ShovelKnight::ShovelKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
+        socd::SocdPair{ &InputState::left,   &InputState::right  },
         socd::SocdPair{ &InputState::down,   &InputState::mod_x  },
         socd::SocdPair{ &InputState::c_left, &InputState::c_right},
         socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
     };
 }
 
-void ShovelKnight::UpdateDigitalOutputs(InputState &inputs) {
-    _outputs->dpadLeft = inputs.left;
-    _outputs->dpadRight = inputs.right;
-    _outputs->dpadDown = inputs.down;
-    _outputs->dpadUp = inputs.mod_x;
+void ShovelKnight::UpdateDigitalOutputs() {
+    _outputs->dpadLeft = _inputs->left;
+    _outputs->dpadRight = _inputs->right;
+    _outputs->dpadDown = _inputs->down;
+    _outputs->dpadUp = _inputs->mod_x;
 
-    _outputs->b = inputs.x; // Jump
-    _outputs->a = inputs.a; // Attack
-    _outputs->y = inputs.b; // Attack
-    _outputs->x = inputs.z; // Subweapon
-    _outputs->buttonL = inputs.r; // Subweapon prev
-    _outputs->buttonR = inputs.y; // Subweapon next
+    _outputs->b = _inputs->x; // Jump
+    _outputs->a = _inputs->a; // Attack
+    _outputs->y = _inputs->b; // Attack
+    _outputs->x = _inputs->z; // Subweapon
+    _outputs->buttonL = _inputs->r; // Subweapon prev
+    _outputs->buttonR = _inputs->y; // Subweapon next
 
-    _outputs->select = inputs.lightshield; // Inventory
-    _outputs->start = inputs.start; // Pause
+    _outputs->select = _inputs->lightshield; // Inventory
+    _outputs->start = _inputs->start; // Pause
 }
 
-void ShovelKnight::UpdateAnalogOutputs(InputState &inputs) {
+void ShovelKnight::UpdateAnalogOutputs() {
     UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.mod_x,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
+        _inputs->left,
+        _inputs->right,
+        _inputs->down,
+        _inputs->mod_x,
+        _inputs->c_left,
+        _inputs->c_right,
+        _inputs->c_down,
+        _inputs->c_up
     );
 }

--- a/src/modes/extra/ShovelKnight.cpp
+++ b/src/modes/extra/ShovelKnight.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/ShovelKnight.hpp"
 
-#define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_MAX 255
+#define ANALOG_STICK_LENGTH 127
 
 ShovelKnight::ShovelKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/extra/ShovelKnight.cpp
+++ b/src/modes/extra/ShovelKnight.cpp
@@ -10,24 +10,24 @@ ShovelKnight::ShovelKnight(socd::SocdType socd_type) : ControllerMode(socd_type)
     };
 }
 
-void ShovelKnight::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.dpadLeft = inputs.left;
-    outputs.dpadRight = inputs.right;
-    outputs.dpadDown = inputs.down;
-    outputs.dpadUp = inputs.mod_x;
+void ShovelKnight::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->dpadLeft = inputs.left;
+    outputs->dpadRight = inputs.right;
+    outputs->dpadDown = inputs.down;
+    outputs->dpadUp = inputs.mod_x;
 
-    outputs.b = inputs.x; // Jump
-    outputs.a = inputs.a; // Attack
-    outputs.y = inputs.b; // Attack
-    outputs.x = inputs.z; // Subweapon
-    outputs.buttonL = inputs.r; // Subweapon prev
-    outputs.buttonR = inputs.y; // Subweapon next
+    outputs->b = inputs.x; // Jump
+    outputs->a = inputs.a; // Attack
+    outputs->y = inputs.b; // Attack
+    outputs->x = inputs.z; // Subweapon
+    outputs->buttonL = inputs.r; // Subweapon prev
+    outputs->buttonR = inputs.y; // Subweapon next
 
-    outputs.select = inputs.lightshield; // Inventory
-    outputs.start = inputs.start; // Pause
+    outputs->select = inputs.lightshield; // Inventory
+    outputs->start = inputs.start; // Pause
 }
 
-void ShovelKnight::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void ShovelKnight::UpdateAnalogOutputs(InputState &inputs) {
     UpdateDirections(
         inputs.left,
         inputs.right,
@@ -36,7 +36,6 @@ void ShovelKnight::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs)
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 }

--- a/src/modes/extra/ShovelKnight.cpp
+++ b/src/modes/extra/ShovelKnight.cpp
@@ -1,7 +1,6 @@
 #include "modes/extra/ShovelKnight.hpp"
 
 #define ANALOG_STICK_MIN 1
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
 ShovelKnight::ShovelKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/extra/ShovelKnight.cpp
+++ b/src/modes/extra/ShovelKnight.cpp
@@ -11,20 +11,20 @@ ShovelKnight::ShovelKnight(socd::SocdType socd_type) : ControllerMode(socd_type)
 }
 
 void ShovelKnight::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->dpadLeft = inputs.left;
-    outputs->dpadRight = inputs.right;
-    outputs->dpadDown = inputs.down;
-    outputs->dpadUp = inputs.mod_x;
+    _outputs->dpadLeft = inputs.left;
+    _outputs->dpadRight = inputs.right;
+    _outputs->dpadDown = inputs.down;
+    _outputs->dpadUp = inputs.mod_x;
 
-    outputs->b = inputs.x; // Jump
-    outputs->a = inputs.a; // Attack
-    outputs->y = inputs.b; // Attack
-    outputs->x = inputs.z; // Subweapon
-    outputs->buttonL = inputs.r; // Subweapon prev
-    outputs->buttonR = inputs.y; // Subweapon next
+    _outputs->b = inputs.x; // Jump
+    _outputs->a = inputs.a; // Attack
+    _outputs->y = inputs.b; // Attack
+    _outputs->x = inputs.z; // Subweapon
+    _outputs->buttonL = inputs.r; // Subweapon prev
+    _outputs->buttonR = inputs.y; // Subweapon next
 
-    outputs->select = inputs.lightshield; // Inventory
-    outputs->start = inputs.start; // Pause
+    _outputs->select = inputs.lightshield; // Inventory
+    _outputs->start = inputs.start; // Pause
 }
 
 void ShovelKnight::UpdateAnalogOutputs(InputState &inputs) {

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -60,51 +60,51 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     if (inputs.mod_x) {
         // MX + Horizontal = 6625 = 53
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 53);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
             // Horizontal Shield tilt = 51
             if (shield_button_pressed) {
-                outputs.leftStickX = 128 + (directions.x * 51);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
             }
             // Horizontal Tilts = 36
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 36);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
             }
         }
         // MX + Vertical = 44
         if (directions.vertical) {
-            outputs.leftStickY = 128 + (directions.y * 44);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
             // Vertical Shield Tilt = 51
             if (shield_button_pressed) {
-                outputs.leftStickY = 128 + (directions.y * 51);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 51);
             }
         }
         if (directions.diagonal) {
             // MX + q1/2/3/4 = 53 40
-            outputs.leftStickX = 128 + (directions.x * 53);
-            outputs.leftStickY = 128 + (directions.y * 40);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 40);
             if (shield_button_pressed) {
                 // MX + L, R, LS, and MS + q1/2/3/4 = 6375 3750 = 51 30
-                outputs.leftStickX = 128 + (directions.x * 51);
-                outputs.leftStickY = 128 + (directions.y * 30);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 30);
             }
         }
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            outputs.rightStickX = 128 + (directions.cx * 127);
-            outputs.rightStickY = 128 + (directions.y * 59);
+            outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 127);
+            outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.y * 59);
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             // (33.44) = 53 40
-            outputs.leftStickX = 128 + (directions.x * 53);
-            outputs.leftStickY = 128 + (directions.y * 40);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 40);
 
             // Angled Ftilts
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 36);
-                outputs.leftStickY = 128 + (directions.y * 26);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 26);
             }
         }
     }
@@ -112,32 +112,32 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     if (inputs.mod_y) {
         // MY + Horizontal (even if shield is held) = 41
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 41);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 41);
             // MY Horizontal Tilts
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 36);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
             }
         }
         // MY + Vertical (even if shield is held) = 44
         if (directions.vertical) {
-            outputs.leftStickY = 128 + (directions.y * 44);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
             // MY Vertical Tilts
             if (inputs.a) {
-                outputs.leftStickY = 128 + (directions.y * 36);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 36);
             }
         }
         if (directions.diagonal) {
             // MY + q1/2/3/4 = 41 44
-            outputs.leftStickX = 128 + (directions.x * 41);
-            outputs.leftStickY = 128 + (directions.y * 44);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 41);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
             if (shield_button_pressed) {
                 // MY + L, R, LS, and MS + q1/2 = 38 70
-                outputs.leftStickX = 128 + (directions.x * 38);
-                outputs.leftStickY = 128 + (directions.y * 70);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 38);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
                 // MY + L, R, LS, and MS + q3/4 = 40 68
                 if (directions.x == -1) {
-                    outputs.leftStickX = 128 + (directions.x * 40);
-                    outputs.leftStickY = 128 + (directions.y * 68);
+                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 40);
+                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 68);
                 }
             }
         }
@@ -145,13 +145,13 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
             // (56.56) = 41 44
-            outputs.leftStickX = 128 + (directions.x * 41);
-            outputs.leftStickY = 128 + (directions.y * 44);
+            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 41);
+            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
 
             // MY Pivot Uptilt/Dtilt
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 34);
-                outputs.leftStickY = 128 + (directions.y * 38);
+                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 34);
+                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 38);
             }
         }
     }
@@ -160,8 +160,8 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
         // 5250 8500 = 42 68
-        outputs.rightStickX = 128 + (directions.cx * 42);
-        outputs.rightStickY = 128 + (directions.cy * 68);
+        outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 42);
+        outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.cy * 68);
     }
 
     if (inputs.l) {
@@ -174,8 +174,8 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = 128;
-        outputs.rightStickY = 128;
+        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
+        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -12,27 +12,27 @@ Ultimate2::Ultimate2(socd::SocdType socd_type) : ControllerMode(socd_type, 100) 
 }
 
 void Ultimate2::UpdateDigitalOutputs(InputState &inputs) {
-    outputs->a = inputs.a;
-    outputs->b = inputs.b;
-    outputs->x = inputs.x;
-    outputs->y = inputs.y;
-    outputs->buttonR = inputs.z;
-    outputs->triggerLDigital = inputs.l;
-    outputs->triggerRDigital = inputs.r;
-    outputs->start = inputs.start;
+    _outputs->a = inputs.a;
+    _outputs->b = inputs.b;
+    _outputs->x = inputs.x;
+    _outputs->y = inputs.y;
+    _outputs->buttonR = inputs.z;
+    _outputs->triggerLDigital = inputs.l;
+    _outputs->triggerRDigital = inputs.r;
+    _outputs->start = inputs.start;
 
     // D-Pad
     if (inputs.mod_x && inputs.mod_y) {
-        outputs->dpadUp = inputs.c_up;
-        outputs->dpadDown = inputs.c_down;
-        outputs->dpadLeft = inputs.c_left;
-        outputs->dpadRight = inputs.c_right;
+        _outputs->dpadUp = inputs.c_up;
+        _outputs->dpadDown = inputs.c_down;
+        _outputs->dpadLeft = inputs.c_left;
+        _outputs->dpadRight = inputs.c_right;
     }
 
     if (inputs.select)
-        outputs->dpadLeft = true;
+        _outputs->dpadLeft = true;
     if (inputs.home)
-        outputs->dpadRight = true;
+        _outputs->dpadRight = true;
 }
 
 void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
@@ -82,7 +82,7 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
+            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
         }
 
         /* Up B angles */
@@ -143,11 +143,11 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
     }
 
     if (inputs.l) {
-        outputs->triggerLAnalog = 140;
+        _outputs->triggerLAnalog = 140;
     }
 
     if (inputs.r) {
-        outputs->triggerRAnalog = 140;
+        _outputs->triggerRAnalog = 140;
     }
 
     // Shut off c-stick when using dpad layer.
@@ -157,7 +157,7 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs->leftStickX = inputs.nunchuk_x;
-        outputs->leftStickY = inputs.nunchuk_y;
+        _outputs->leftStickX = inputs.nunchuk_x;
+        _outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -1,15 +1,8 @@
 /* Ultimate2 profile by Taker */
 #include "modes/extra/Ultimate2.hpp"
 
-Ultimate2::Ultimate2(socd::SocdType socd_type) : ControllerMode(socd_type, 100) {
-    _socd_pair_count = 4;
-    _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
-    };
-}
+Ultimate2::Ultimate2(socd::SocdType socd_type)
+    : PlatformFighter(socd_type) { }
 
 void Ultimate2::UpdateDigitalOutputs(InputState &inputs) {
     _outputs->a = inputs.a;

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -11,31 +11,31 @@ Ultimate2::Ultimate2(socd::SocdType socd_type) : ControllerMode(socd_type, 100) 
     };
 }
 
-void Ultimate2::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
-    outputs.a = inputs.a;
-    outputs.b = inputs.b;
-    outputs.x = inputs.x;
-    outputs.y = inputs.y;
-    outputs.buttonR = inputs.z;
-    outputs.triggerLDigital = inputs.l;
-    outputs.triggerRDigital = inputs.r;
-    outputs.start = inputs.start;
+void Ultimate2::UpdateDigitalOutputs(InputState &inputs) {
+    outputs->a = inputs.a;
+    outputs->b = inputs.b;
+    outputs->x = inputs.x;
+    outputs->y = inputs.y;
+    outputs->buttonR = inputs.z;
+    outputs->triggerLDigital = inputs.l;
+    outputs->triggerRDigital = inputs.r;
+    outputs->start = inputs.start;
 
     // D-Pad
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.dpadUp = inputs.c_up;
-        outputs.dpadDown = inputs.c_down;
-        outputs.dpadLeft = inputs.c_left;
-        outputs.dpadRight = inputs.c_right;
+        outputs->dpadUp = inputs.c_up;
+        outputs->dpadDown = inputs.c_down;
+        outputs->dpadLeft = inputs.c_left;
+        outputs->dpadRight = inputs.c_right;
     }
 
     if (inputs.select)
-        outputs.dpadLeft = true;
+        outputs->dpadLeft = true;
     if (inputs.home)
-        outputs.dpadRight = true;
+        outputs->dpadRight = true;
 }
 
-void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
+void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
     // Coordinate calculations to make modifier handling simpler.
     UpdateDirections(
         inputs.left,
@@ -45,8 +45,7 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         inputs.c_left,
         inputs.c_right,
         inputs.c_down,
-        inputs.c_up,
-        outputs
+        inputs.c_up
     );
 
     bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
@@ -54,44 +53,44 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     if (inputs.mod_x) {
         // MX + Horizontal
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 5300);
+            SetLeftStickX(5300);
             // Horizontal Shield tilt
             if (shield_button_pressed) {
-                SetLeftStickX(outputs, 5100);
+                SetLeftStickX(5100);
             }
             // Horizontal Tilts
             if (inputs.a) {
-                SetLeftStickX(outputs, 3600);
+                SetLeftStickX(3600);
             }
         }
         // MX + Vertical
         if (directions.vertical) {
-            SetLeftStickY(outputs, 4400);
+            SetLeftStickY(4400);
             // Vertical Shield Tilt
             if (shield_button_pressed) {
-                SetLeftStickX(outputs, 5100);
+                SetLeftStickX(5100);
             }
         }
         if (directions.diagonal) {
             // MX + q1/2/3/4
-            SetLeftStick(outputs, 5300, 4000); // 37.04247°
+            SetLeftStick(5300, 4000); // 37.04247°
             if (shield_button_pressed) {
                 // MX + L, R, LS, and MS + q1/2/3/4
-                SetLeftStick(outputs, 5100, 3000); // 30.46554°
+                SetLeftStick(5100, 3000); // 30.46554°
             }
         }
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
+            SetStick(&outputs->rightStickX, &outputs->rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 5300, 4000); // 37.04247°
+            SetLeftStick(5300, 4000); // 37.04247°
             // Angled Ftilts
             if (inputs.a) {
-                SetLeftStick(outputs, 3600, 2600); // 35.83765°
+                SetLeftStick(3600, 2600); // 35.83765°
             }
         }
     }
@@ -99,40 +98,40 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     if (inputs.mod_y) {
         // MY + Horizontal (even if shield is held)
         if (directions.horizontal) {
-            SetLeftStickX(outputs, 4100);
+            SetLeftStickX(4100);
             // MY Horizontal Tilts
             if (inputs.a) {
-                SetLeftStickX(outputs, 3600);
+                SetLeftStickX(3600);
             }
         }
         // MY + Vertical (even if shield is held)
         if (directions.vertical) {
-            SetLeftStickY(outputs, 4400);
+            SetLeftStickY(4400);
             // MY Vertical Tilts
             if (inputs.a) {
-                SetLeftStickY(outputs, 3600);
+                SetLeftStickY(3600);
             }
         }
         if (directions.diagonal) {
             // MY + q1/2/3/4
-            SetLeftStick(outputs, 4100, 4400); // 47.02136°
+            SetLeftStick(4100, 4400); // 47.02136°
             if (shield_button_pressed) {
                 // MY + L, R, LS, and MS + q1/2
-                SetLeftStick(outputs, 3800, 7000); // 61.50436°
+                SetLeftStick(3800, 7000); // 61.50436°
                 // MY + L, R, LS, and MS + q3/4 = 40 68
                 if (directions.x < 0) {
-                    SetLeftStick(outputs, 4000, 6800); // 59.53446°
+                    SetLeftStick(4000, 6800); // 59.53446°
                 }
             }
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            SetLeftStick(outputs, 4100, 4400); // 47.02136°
+            SetLeftStick(4100, 4400); // 47.02136°
 
             // MY Pivot Uptilt/Dtilt
             if (inputs.a) {
-                SetLeftStick(outputs, 3400, 3800); // 48.17983°
+                SetLeftStick(3400, 3800); // 48.17983°
             }
         }
     }
@@ -140,25 +139,25 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        SetRightStick(outputs, 4200, 6800); // 58.29857°
+        SetRightStick(4200, 6800); // 58.29857°
     }
 
     if (inputs.l) {
-        outputs.triggerLAnalog = 140;
+        outputs->triggerLAnalog = 140;
     }
 
     if (inputs.r) {
-        outputs.triggerRAnalog = 140;
+        outputs->triggerRAnalog = 140;
     }
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        SetRightStick(outputs, 0000, 0000); // 0°
+        SetRightStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.
     if (inputs.nunchuk_connected) {
-        outputs.leftStickX = inputs.nunchuk_x;
-        outputs.leftStickY = inputs.nunchuk_y;
+        outputs->leftStickX = inputs.nunchuk_x;
+        outputs->leftStickY = inputs.nunchuk_y;
     }
 }

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -52,100 +52,87 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
 
     if (inputs.mod_x) {
-        // MX + Horizontal = 6625 = 53
+        // MX + Horizontal
         if (directions.horizontal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-            // Horizontal Shield tilt = 51
+            SetLeftStickX(outputs, 5300);
+            // Horizontal Shield tilt
             if (shield_button_pressed) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
+                SetLeftStickX(outputs, 5100);
             }
-            // Horizontal Tilts = 36
+            // Horizontal Tilts
             if (inputs.a) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
+                SetLeftStickX(outputs, 3600);
             }
         }
-        // MX + Vertical = 44
+        // MX + Vertical
         if (directions.vertical) {
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
-            // Vertical Shield Tilt = 51
+            SetLeftStickY(outputs, 4400);
+            // Vertical Shield Tilt
             if (shield_button_pressed) {
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 51);
+                SetLeftStickX(outputs, 5100);
             }
         }
         if (directions.diagonal) {
-            // MX + q1/2/3/4 = 53 40
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 40);
+            // MX + q1/2/3/4
+            SetLeftStick(outputs, 5300, 4000); // 37.04247°
             if (shield_button_pressed) {
-                // MX + L, R, LS, and MS + q1/2/3/4 = 6375 3750 = 51 30
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 51);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 30);
+                // MX + L, R, LS, and MS + q1/2/3/4
+                SetLeftStick(outputs, 5100, 3000); // 30.46554°
             }
         }
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 127);
-            outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.y * 59);
+            SetStick(&outputs.rightStickX, &outputs.rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            // (33.44) = 53 40
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 53);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 40);
-
+            SetLeftStick(outputs, 5300, 4000); // 37.04247°
             // Angled Ftilts
             if (inputs.a) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 26);
+                SetLeftStick(outputs, 3600, 2600); // 35.83765°
             }
         }
     }
 
     if (inputs.mod_y) {
-        // MY + Horizontal (even if shield is held) = 41
+        // MY + Horizontal (even if shield is held)
         if (directions.horizontal) {
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 41);
+            SetLeftStickX(outputs, 4100);
             // MY Horizontal Tilts
             if (inputs.a) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 36);
+                SetLeftStickX(outputs, 3600);
             }
         }
-        // MY + Vertical (even if shield is held) = 44
+        // MY + Vertical (even if shield is held)
         if (directions.vertical) {
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
+            SetLeftStickY(outputs, 4400);
             // MY Vertical Tilts
             if (inputs.a) {
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 36);
+                SetLeftStickY(outputs, 3600);
             }
         }
         if (directions.diagonal) {
-            // MY + q1/2/3/4 = 41 44
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 41);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
+            // MY + q1/2/3/4
+            SetLeftStick(outputs, 4100, 4400); // 47.02136°
             if (shield_button_pressed) {
-                // MY + L, R, LS, and MS + q1/2 = 38 70
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 38);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 70);
+                // MY + L, R, LS, and MS + q1/2
+                SetLeftStick(outputs, 3800, 7000); // 61.50436°
                 // MY + L, R, LS, and MS + q3/4 = 40 68
-                if (directions.x == -1) {
-                    outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 40);
-                    outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 68);
+                if (directions.x < 0) {
+                    SetLeftStick(outputs, 4000, 6800); // 59.53446°
                 }
             }
         }
 
         /* Up B angles */
         if (directions.diagonal && !shield_button_pressed) {
-            // (56.56) = 41 44
-            outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 41);
-            outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 44);
+            SetLeftStick(outputs, 4100, 4400); // 47.02136°
 
             // MY Pivot Uptilt/Dtilt
             if (inputs.a) {
-                outputs.leftStickX = ANALOG_STICK_NEUTRAL + (directions.x * 34);
-                outputs.leftStickY = ANALOG_STICK_NEUTRAL + (directions.y * 38);
+                SetLeftStick(outputs, 3400, 3800); // 48.17983°
             }
         }
     }
@@ -153,9 +140,7 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        // 5250 8500 = 42 68
-        outputs.rightStickX = ANALOG_STICK_NEUTRAL + (directions.cx * 42);
-        outputs.rightStickY = ANALOG_STICK_NEUTRAL + (directions.cy * 68);
+        SetRightStick(outputs, 4200, 6800); // 58.29857°
     }
 
     if (inputs.l) {
@@ -168,8 +153,7 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
 
     // Shut off c-stick when using dpad layer.
     if (inputs.mod_x && inputs.mod_y) {
-        outputs.rightStickX = ANALOG_STICK_NEUTRAL;
-        outputs.rightStickY = ANALOG_STICK_NEUTRAL;
+        SetRightStick(outputs, 0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -122,7 +122,7 @@ void Ultimate2::UpdateAnalogOutputs() {
     // C-stick ASDI Slideoff angle overrides any other C-stick modifiers (such as
     // angled fsmash).
     if (directions.cx != 0 && directions.cy != 0) {
-        SetRightStick(4200, 6800); // 58.29857°
+        SetCStick(4200, 6800); // 58.29857°
     }
 
     if (_inputs->l) {
@@ -135,7 +135,7 @@ void Ultimate2::UpdateAnalogOutputs() {
 
     // Shut off c-stick when using dpad layer.
     if (_inputs->mod_x && _inputs->mod_y) {
-        SetRightStick(0000, 0000); // 0°
+        SetCStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -4,36 +4,36 @@
 Ultimate2::Ultimate2(socd::SocdType socd_type)
     : PlatformFighter(socd_type) { }
 
-void Ultimate2::UpdateDigitalOutputs(InputState &inputs) {
-    _outputs->a = inputs.a;
-    _outputs->b = inputs.b;
-    _outputs->x = inputs.x;
-    _outputs->y = inputs.y;
-    _outputs->buttonR = inputs.z;
-    _outputs->triggerLDigital = inputs.l;
-    _outputs->triggerRDigital = inputs.r;
-    _outputs->start = inputs.start;
+void Ultimate2::UpdateDigitalOutputs() {
+    _outputs->a = _inputs->a;
+    _outputs->b = _inputs->b;
+    _outputs->x = _inputs->x;
+    _outputs->y = _inputs->y;
+    _outputs->buttonR = _inputs->z;
+    _outputs->triggerLDigital = _inputs->l;
+    _outputs->triggerRDigital = _inputs->r;
+    _outputs->start = _inputs->start;
 
     // D-Pad
-    if (inputs.mod_x && inputs.mod_y) {
-        _outputs->dpadUp = inputs.c_up;
-        _outputs->dpadDown = inputs.c_down;
-        _outputs->dpadLeft = inputs.c_left;
-        _outputs->dpadRight = inputs.c_right;
+    if (_inputs->mod_x && _inputs->mod_y) {
+        _outputs->dpadUp = _inputs->c_up;
+        _outputs->dpadDown = _inputs->c_down;
+        _outputs->dpadLeft = _inputs->c_left;
+        _outputs->dpadRight = _inputs->c_right;
     }
 
-    if (inputs.select)
+    if (_inputs->select)
         _outputs->dpadLeft = true;
-    if (inputs.home)
+    if (_inputs->home)
         _outputs->dpadRight = true;
 }
 
-void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
+void Ultimate2::UpdateAnalogOutputs() {
     UpdateDirections();
 
-    bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
+    bool shield_button_pressed = _inputs->l || _inputs->r || _inputs->lightshield || _inputs->midshield;
 
-    if (inputs.mod_x) {
+    if (_inputs->mod_x) {
         // MX + Horizontal
         if (directions.horizontal) {
             SetLeftStickX(5300);
@@ -42,7 +42,7 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
                 SetLeftStickX(5100);
             }
             // Horizontal Tilts
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStickX(3600);
             }
         }
@@ -72,18 +72,18 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
         if (directions.diagonal && !shield_button_pressed) {
             SetLeftStick(5300, 4000); // 37.04247°
             // Angled Ftilts
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStick(3600, 2600); // 35.83765°
             }
         }
     }
 
-    if (inputs.mod_y) {
+    if (_inputs->mod_y) {
         // MY + Horizontal (even if shield is held)
         if (directions.horizontal) {
             SetLeftStickX(4100);
             // MY Horizontal Tilts
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStickX(3600);
             }
         }
@@ -91,7 +91,7 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
         if (directions.vertical) {
             SetLeftStickY(4400);
             // MY Vertical Tilts
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStickY(3600);
             }
         }
@@ -113,7 +113,7 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
             SetLeftStick(4100, 4400); // 47.02136°
 
             // MY Pivot Uptilt/Dtilt
-            if (inputs.a) {
+            if (_inputs->a) {
                 SetLeftStick(3400, 3800); // 48.17983°
             }
         }
@@ -125,22 +125,22 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
         SetRightStick(4200, 6800); // 58.29857°
     }
 
-    if (inputs.l) {
+    if (_inputs->l) {
         _outputs->triggerLAnalog = 140;
     }
 
-    if (inputs.r) {
+    if (_inputs->r) {
         _outputs->triggerRAnalog = 140;
     }
 
     // Shut off c-stick when using dpad layer.
-    if (inputs.mod_x && inputs.mod_y) {
+    if (_inputs->mod_x && _inputs->mod_y) {
         SetRightStick(0000, 0000); // 0°
     }
 
     // Nunchuk overrides left stick.
-    if (inputs.nunchuk_connected) {
-        _outputs->leftStickX = inputs.nunchuk_x;
-        _outputs->leftStickY = inputs.nunchuk_y;
+    if (_inputs->nunchuk_connected) {
+        _outputs->leftStickX = _inputs->nunchuk_x;
+        _outputs->leftStickY = _inputs->nunchuk_y;
     }
 }

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -2,7 +2,6 @@
 #include "modes/extra/Ultimate2.hpp"
 
 #define ANALOG_STICK_MIN 28
-#define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 228
 
 Ultimate2::Ultimate2(socd::SocdType socd_type) : ControllerMode(socd_type) {

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -1,8 +1,7 @@
 /* Ultimate2 profile by Taker */
 #include "modes/extra/Ultimate2.hpp"
 
-#define ANALOG_STICK_MIN 28
-#define ANALOG_STICK_MAX 228
+#define ANALOG_STICK_LENGTH 100
 
 Ultimate2::Ultimate2(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 4;

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -29,17 +29,7 @@ void Ultimate2::UpdateDigitalOutputs(InputState &inputs) {
 }
 
 void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
-    // Coordinate calculations to make modifier handling simpler.
-    UpdateDirections(
-        inputs.left,
-        inputs.right,
-        inputs.down,
-        inputs.up,
-        inputs.c_left,
-        inputs.c_right,
-        inputs.c_down,
-        inputs.c_up
-    );
+    UpdateDirections();
 
     bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
 

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -82,7 +82,7 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs) {
 
         // Angled fsmash/ftilt with C-Stick + MX
         if (directions.cx != 0) {
-            SetStick(&_outputs->rightStickX, &_outputs->rightStickY, directions.cx, directions.y, 12700, 5900); // 24.91802°
+            SetAngledFSmash(12700, 5900); // 24.91802°
         }
 
         /* Up B angles */

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -1,9 +1,7 @@
 /* Ultimate2 profile by Taker */
 #include "modes/extra/Ultimate2.hpp"
 
-#define ANALOG_STICK_LENGTH 100
-
-Ultimate2::Ultimate2(socd::SocdType socd_type) : ControllerMode(socd_type) {
+Ultimate2::Ultimate2(socd::SocdType socd_type) : ControllerMode(socd_type, 100) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
         socd::SocdPair{&InputState::left,    &InputState::right  },
@@ -48,9 +46,6 @@ void Ultimate2::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         inputs.c_right,
         inputs.c_down,
         inputs.c_up,
-        ANALOG_STICK_MIN,
-        ANALOG_STICK_NEUTRAL,
-        ANALOG_STICK_MAX,
         outputs
     );
 


### PR DESCRIPTION
The primary goal of this PR is to employ normalized coordinates from 0 to 10,000 per quadrant, equivalent to the 0 to 1 coordinate system familiar to the Melee community. I also cleaned up the comments, removing any reference to `0..255` coordinates and updating the angles to be uniformly accurate to 5 decimal places.

In doing so, I chose to refactor the `&input` and `&output` parameters of `ControllerMode` to `protected` pointers, which are updated to point to the `CommunicationBackend`'s structs, once per update loop.

I also refactored `ANALOG_STICK_MIN` and `ANALOG_STICK_MAX` to instead use a single `analog_stick_length` property of `ControllerMode`, which is set in the constructor. This was necessary to implement the normalized coordinate systems across different game modes.

`ANALOG_STICK_NEUTRAL` is still a `#define` but was moved to `state.hpp` and is used in place of `128` throughout the codebase, where appropriate.

These changes were made as part of a refactoring pass that I'm doing for my own forks. I'm just submitting this as a PR in case it's preferred here as well.

---

I have moved these normalized coordinate functions to a `PlatformFighter` base class, which all platform fighter modes (Melee, PM, Ultimate, and Rivals) now inherit from.