### PR TITLE
Update Rivals Mode

### DIFF
--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -42,6 +42,8 @@ void RivalsOfAether::UpdateDigitalOutputs(InputState &inputs, OutputState &outpu
 
     outputs.select = inputs.select;
     outputs.home = inputs.home;
+    outputs.leftStickClick = inputs.lightshield;
+    outputs.rightStickClick = inputs.midshield;
 }
 
 void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
@@ -63,39 +65,40 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &output
 
     bool shield_button_pressed = inputs.l || inputs.r;
 
+
+    // 48 total DI angles, 24 total Up b angles, 16 total airdodge angles
+
     if (inputs.mod_x) {
         if (directions.horizontal) {
             outputs.leftStickX = 128 + (directions.x * 66);
         }
 
-        // Angled fsmash
-        if (directions.cx != 0) {
-            outputs.rightStickX = 128 + (directions.cx * 65);
-            outputs.rightStickY = 128 + (directions.y * 23);
+        if(directions.vertical) {
+            outputs.leftStickY = 128 + (directions.y * 44);
         }
 
-        // Need to check coord system in RoA
-
-        /* Up B angles */
-        if (directions.diagonal && !shield_button_pressed) {
+        /* Extra DI, Air Dodge, and Up B angles */
+        if (directions.diagonal) {
             outputs.leftStickX = 128 + (directions.x * 59);
             outputs.leftStickY = 128 + (directions.y * 23);
 
+            // Angles just for DI and Up B
             if (inputs.c_down) {
                 outputs.leftStickX = 128 + (directions.x * 49);
                 outputs.leftStickY = 128 + (directions.y * 24);
             }
 
+            // Angles just for DI
             if (inputs.c_left) {
                 outputs.leftStickX = 128 + (directions.x * 52);
                 outputs.leftStickY = 128 + (directions.y * 31);
             }
-
+      
             if (inputs.c_up) {
                 outputs.leftStickX = 128 + (directions.x * 49);
                 outputs.leftStickY = 128 + (directions.y * 35);
             }
-
+     
             if (inputs.c_right) {
                 outputs.leftStickX = 128 + (directions.x * 51);
                 outputs.leftStickY = 128 + (directions.y * 43);
@@ -108,49 +111,35 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &output
             outputs.leftStickX = 128 + (directions.x * 44);
         }
 
-        /* Up B angles */
-        if (directions.diagonal && !shield_button_pressed) {
+        if(directions.vertical) {
+            outputs.leftStickY = 128 + (directions.y * 67);
+        }
+
+        /* Extra DI, Air Dodge, and Up B angles */
+        if (directions.diagonal) {
             outputs.leftStickX = 128 + (directions.x * 44);
             outputs.leftStickY = 128 + (directions.y * 113);
 
+            // Angles just for DI and Up B
             if (inputs.c_down) {
                 outputs.leftStickX = 128 + (directions.x * 44);
                 outputs.leftStickY = 128 + (directions.y * 90);
             }
 
+            // Angles just for DI
             if (inputs.c_left) {
                 outputs.leftStickX = 128 + (directions.x * 44);
-                outputs.leftStickY = 128 + (directions.y * 74);
+                outputs.leftStickY = 128 + (directions.y * 90);
             }
-
+      
             if (inputs.c_up) {
                 outputs.leftStickX = 128 + (directions.x * 45);
                 outputs.leftStickY = 128 + (directions.y * 63);
             }
-
+     
             if (inputs.c_right) {
                 outputs.leftStickX = 128 + (directions.x * 47);
                 outputs.leftStickY = 128 + (directions.y * 57);
-            }
-        }
-    }
-
-    if (inputs.l) {
-        if (directions.horizontal)
-            outputs.leftStickX = 128 + (directions.x * 100);
-        if (directions.vertical)
-            outputs.leftStickY = 128 + (directions.y * 100);
-        if (directions.horizontal && (directions.y == -1)) {
-            outputs.leftStickX = 128 + (directions.x * 100);
-            outputs.leftStickY = ANALOG_STICK_MIN;
-        }
-    }
-
-    if (inputs.r) {
-        if (directions.diagonal) {
-            if (inputs.mod_y) {
-                outputs.leftStickX = 128 + (directions.x * 40);
-                outputs.leftStickY = 128 + (directions.y * 68);
             }
         }
     }


### PR DESCRIPTION
Since I first made the Rivals mode, I've learned a bit more about Rivals and about how rectangle controllers work. Rivals mode desperately needed an update which fixed a couple bugs and added some features such as:
- Making sure all 48 DI angles, 24 Zetterburn Up B angles, and 16 Air Dodge angles were accounted for
- Removed unnecessary checks (angled fstrongs aren't a thing in rivals iirc) and other redundant left stick inputs
- Added in MS and LS as extra buttons too (Left stick click and Right stick click)
- Fixed bugs (can now crouch on plats with mod_y and pressing mod_x doesn't stop you from using ftilt)

It'll likely need more testing, but I figured I should drop the PR now since the old Rivals mode is missing important stuff like the angles and crouching on plats.