### PR TITLE
feat: Add L button to Switch Backend

### DIFF
--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -20,9 +20,10 @@ void Ultimate::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
     outputs.b = inputs.b;
     outputs.x = inputs.x;
     outputs.y = inputs.y;
-    outputs.buttonR = inputs.z;
-    outputs.triggerLDigital = inputs.l;
-    outputs.triggerRDigital = inputs.r;
+    outputs.buttonR = inputs.z; // Switch: R
+    outputs.buttonL = inputs.lightshield; // Switch: L
+    outputs.triggerLDigital = inputs.l; // Switch: ZL
+    outputs.triggerRDigital = inputs.r; // Switch:ZR
     outputs.start = inputs.start;
     outputs.select = inputs.select;
     outputs.home = inputs.home;


### PR DESCRIPTION
Uses the "lightshield" button to act as the missing "L" button for the Switch Backend. Previously we had R, ZL, and ZR but not L.
Also there's a newline character added to the end of the file since I used the Github Editor.