### PR TITLE
Fixed several Ultimate pro controller inputs

### DIFF
--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -56,9 +56,10 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
     bool shield_button_pressed = inputs.l || inputs.r || inputs.lightshield || inputs.midshield;
 
     if (inputs.mod_x) {
-        // MX + Horizontal = 6625 = 53
+        // MX + Horizontal = 6625 = 53 
+        // (Zeronia's note: Reduced to 51 to allow ToonLink & YoungLink passive-shield walk)
         if (directions.horizontal) {
-            outputs.leftStickX = 128 + (directions.x * 53);
+            outputs.leftStickX = 128 + (directions.x * 51);
             // Horizontal Shield tilt = 51
             if (shield_button_pressed) {
                 outputs.leftStickX = 128 + (directions.x * 51);
@@ -158,9 +159,10 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
         // MY + Horizontal (even if shield is held) = 41
         if (directions.horizontal) {
             outputs.leftStickX = 128 + (directions.x * 41);
-            // MY Horizontal Tilts
+            // MY Horizontal Tilts 
+            // (Zeronia's note: Reduced to 28 (from 36) to just turnaround and jab, similar to Arte firmware)
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 36);
+                outputs.leftStickX = 128 + (directions.x * 28);
             }
         }
         // MY + Vertical (even if shield is held) = 53
@@ -176,10 +178,11 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
             outputs.leftStickX = 128 + (directions.x * 35);
             outputs.leftStickY = 128 + (directions.y * 53);
             if (shield_button_pressed) {
-                // MY + L, R, LS, and MS + q1/2 = 38 70
-                outputs.leftStickX = 128 + (directions.x * 38);
-                outputs.leftStickY = 128 + (directions.y * 70);
-                // MY + L, R, LS, and MS + q3/4 = 40 68
+                // MY + L, R, LS, and MS + q1/2 = 38 70 (Reverse UpTilt rightwards) 
+                // (Zeronia's note: Reduced to 40 68 to prevent UpSmash)
+                outputs.leftStickX = 128 + (directions.x * 40);
+                outputs.leftStickY = 128 + (directions.y * 68);
+                // MY + L, R, LS, and MS + q3/4 = 40 68 (Reverse UpTilt leftwards)
                 if (directions.x == -1) {
                     outputs.leftStickX = 128 + (directions.x * 40);
                     outputs.leftStickY = 128 + (directions.y * 68);
@@ -240,10 +243,12 @@ void Ultimate::UpdateAnalogOutputs(InputState &inputs, OutputState &outputs) {
                 }
             }
 
-            // MY Pivot Uptilt/Dtilt
+            // MY Pivot Uptilt/Dtilt 
+            // (Zeronia's note: Modifed values so Pivot DTilt works now, consistently too.
+            // Also uh, pretty sure this only affects DTilt, not UpTilt)
             if (inputs.a) {
-                outputs.leftStickX = 128 + (directions.x * 34);
-                outputs.leftStickY = 128 + (directions.y * 38);
+                outputs.leftStickX = 128 + (directions.x * 38);
+                outputs.leftStickY = 128 + (directions.y * 58);
             }
         }
     }


### PR DESCRIPTION
- Fixed reverse UpTilt rightwards. (It used to input Reverse Up Smash if hit fast enough)
- Fixed reverse DTilt for both directions. Works consistently now. (It just didn't work before)

- MX walking now works with Toon Link's passive shield, matching the speed in Arte's firmware. 
- MY walking is now slower (closer to Arte's firmware). Attempting to attack during this will jab, similarly to Arte's firmware.