### PR TITLE
allow tilt attacks with mod x

### DIFF
--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -70,10 +70,18 @@ void RivalsOfAether::UpdateAnalogOutputs(InputState &inputs, OutputState &output
     if (inputs.mod_x) {
         if (directions.horizontal) {
             outputs.leftStickX = 128 + (directions.x * 66);
+            // MX Horizontal Tilts
+            if (inputs.a) {
+                outputs.leftStickX = 128 + (directions.x * 44);
+            }
         }
 
         if(directions.vertical) {
             outputs.leftStickY = 128 + (directions.y * 44);
+            // MX Vertical Tilts
+            if (inputs.a) {
+                outputs.leftStickY = 128 + (directions.y * 67);
+            }
         }
 
         /* Extra DI, Air Dodge, and Up B angles */


### PR DESCRIPTION
In Rivals of Aether mode, holding Mod X now checks if A button is being pressed so that it can change direction values to allow for tilt attacks with Mod X.

I used the values for Mod Y's horizontal and verticals since that works for tilt attacks, but feel free to adjust the values if the chosen values cause issues in other areas.