### PR TITLE
Minor pinout correction of R1 B0XX's Mod X & Y

### DIFF
--- a/config/b0xx_r1/config.cpp
+++ b/config/b0xx_r1/config.cpp
@@ -23,8 +23,8 @@ GpioButtonMapping button_mappings[] = {
     { &InputState::down,    16},
     { &InputState::right,   14},
 
-    { &InputState::mod_x,   6 },
-    { &InputState::mod_y,   8 },
+    { &InputState::mod_x,   8 },
+    { &InputState::mod_y,   6 },
 
     { &InputState::start,   12},
 


### PR DESCRIPTION
I'm not sure if this is only the case on my super old b0xx, but Mod X and Mod Y are swapped when flashing my R1 with the current firmware. I've corrected this for myself in my branch, thought it would be useful here if all R1 b0xxes have the same issue 👀 