### PR TITLE
added Switch 'Capture' button output

### DIFF
--- a/HAL/pico/src/comms/NintendoSwitchBackend.cpp
+++ b/HAL/pico/src/comms/NintendoSwitchBackend.cpp
@@ -125,6 +125,7 @@ void NintendoSwitchBackend::SendReport() {
     _report.l3 = _outputs.leftStickClick;
     _report.r3 = _outputs.rightStickClick;
     _report.home = _outputs.home;
+    _report.capture = _outputs.capture;
 
     // Analog outputs
     _report.lx = (_outputs.leftStickX - 128) * 1.25 + 128;

--- a/include/core/state.hpp
+++ b/include/core/state.hpp
@@ -68,6 +68,7 @@ typedef struct outputstate {
     bool dpadRight = false;
     bool leftStickClick = false;
     bool rightStickClick = false;
+    bool capture = false;
 
     // Analog outputs.
     uint8_t leftStickX = 128;

--- a/src/modes/FgcMode.cpp
+++ b/src/modes/FgcMode.cpp
@@ -25,6 +25,7 @@ void FgcMode::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {
     outputs.start = inputs.start;
     outputs.select = inputs.c_left;
     outputs.home = inputs.c_down;
+    outputs.capture = inputs.l;
 
     // Right hand bottom row
     outputs.a = inputs.b;


### PR DESCRIPTION
The Brook Wingman FGC interprets the "Capture" button as the PS4/5 "Touchpad" button, which is often used in training/practice mode in games like Street Fighter and Tekken. Added a binding for Capture (L) in the FgcMode.