### PR TITLE
Bootsel/Config Rework

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,5 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "platformio.platformio-ide"
-    ],
-    "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,5 +3,8 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/HAL/pico/include/config_defaults.hpp
+++ b/HAL/pico/include/config_defaults.hpp
@@ -142,7 +142,7 @@ const Config default_config = {
         CommunicationBackendConfig {
             .backend_id = COMMS_BACKEND_CONFIGURATOR,
             .activation_binding_count = 1,
-            .activation_binding = { BTN_RT2 },
+            .activation_binding = { BTN_MB1 },
         }
     },
     .keyboard_modes_count = 1,

--- a/config/pico/config.cpp
+++ b/config/pico/config.cpp
@@ -67,7 +67,7 @@ void setup() {
     gpio_input.UpdateInputs(inputs);
 
     // Check bootsel button hold as early as possible for safety.
-    if (inputs.mb1) {
+    if (inputs.rt1) {
         reboot_bootloader();
     }
 


### PR DESCRIPTION
Split into a seperate PR at Haystack's request.

This change accounts for Config mode becoming a much more common input than bootselect by moving Config mode to MB1 (Start) and moving bootselect to RT1 (A). This enables easy access to both commands, while making "Hold Start to configure" a much more user-friendly option. It also allows the two most common current remappers (remapp.ing and remap.box) to maintain usability between their forks and the soon-to-be mainline configurator branch of haybox.