### PR TITLE
build: hotfix for Schism clockrate issue

### DIFF
--- a/config/schism/env.ini
+++ b/config/schism/env.ini
@@ -1,5 +1,6 @@
 [env:schism]
 extends = arduino_pico_base
+board_build.f_cpu = 130000000L
 build_src_filter =
     ${arduino_pico_base.build_src_filter}
     +<config/schism>


### PR DESCRIPTION
Reduced CPU frequency for Schism config down to 130MHz as it seems it was for some unknown reason interfering with i2c comms resulting in the right hand side not working. Will need to do some debugging of this in future.